### PR TITLE
docs: add Wayland selection design and implementation plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 
 # Misc
 # TODO.md
+.worktrees/

--- a/docs/superpowers/plans/2026-04-14-wayland-selection-shortcut.md
+++ b/docs/superpowers/plans/2026-04-14-wayland-selection-shortcut.md
@@ -1,0 +1,281 @@
+# Linux Wayland `typo --selection` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On Linux Wayland, use a system custom shortcut bound to `typo --selection` to capture selection via `Ctrl+C` + clipboard read and feed it into Typo's existing flow; other platforms keep current behavior.
+
+**Architecture:** Add a CLI flag `--selection` that is forwarded to the running instance via Tauri single-instance, then handle it centrally in Rust by simulating `Ctrl+C`, reading the clipboard, and emitting the same UI event used by the existing global shortcut path. Gate behavior to Linux Wayland and reduce reliance on plugin global shortcuts for that environment.
+
+**Tech Stack:** Tauri (Rust), Vue (TypeScript), `tauri-plugin-single-instance`, `tauri-plugin-clipboard-manager`, `enigo` for synthetic key events.
+
+---
+
+## File structure (planned changes)
+
+**Modify**
+
+- `src-tauri/src/lib.rs`: parse `--selection` from argv; implement Linux Wayland selection capture pipeline; forward captured text to frontend.
+- `src/shortcut.ts`: gate global shortcut registration/behavior for Linux Wayland (keep non-Wayland unchanged).
+- `src/App.vue`: fetch session info on startup if needed to drive shortcut gating or UI messaging.
+- `README.md`: add explicit steps for system custom shortcuts on Linux Wayland.
+
+**Potential add**
+
+- `src-tauri/src/platform.rs` (or similar): small helper utilities for session detection + argument parsing (only if `lib.rs` gets unwieldy).
+
+## Task 1: Detect Linux Wayland session reliably
+
+**Files:**
+
+- Modify: `src-tauri/src/lib.rs`
+- **Step 1: Add a helper function for Wayland detection**
+
+Implement a best-effort Wayland check without external deps:
+
+```rust
+fn is_linux_wayland_session() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+    // Common indicators:
+    // - WAYLAND_DISPLAY is set in native Wayland sessions
+    // - XDG_SESSION_TYPE may be "wayland"
+    let wayland_display = std::env::var_os("WAYLAND_DISPLAY").is_some();
+    let session_type = std::env::var("XDG_SESSION_TYPE").ok().unwrap_or_default();
+    wayland_display || session_type.eq_ignore_ascii_case("wayland")
+}
+```
+
+- **Step 2: Add a debug log when Wayland path is active**
+
+Add a `println!` (or `log` if project already uses it) at app startup:
+
+```rust
+println!("is_linux_wayland_session={}", is_linux_wayland_session());
+```
+
+- **Step 3: Build to ensure no Rust errors**
+
+Run: `pnpm -C src-tauri tauri build` (or project’s existing build command)  
+Expected: compilation succeeds.
+
+- **Step 4: Commit**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "feat(linux): detect Wayland session for selection flow"
+```
+
+## Task 2: Implement selection capture via `Ctrl+C` + clipboard read
+
+**Files:**
+
+- Modify: `src-tauri/src/lib.rs`
+- **Step 1: Implement a synchronous copy-to-clipboard function**
+
+Add a function that:
+
+1. sends `Ctrl+C` via enigo
+2. sleeps 80-150ms
+3. reads clipboard text from a window or app handle
+
+Example shape:
+
+```rust
+fn copy_selection_and_read_clipboard(window: &tauri::Window) -> Result<String, String> {
+    let mut enigo = enigo::Enigo::new(&enigo::Settings::default()).map_err(|e| e.to_string())?;
+
+    // Ctrl + C
+    enigo.key(enigo::Key::Control, enigo::Direction::Press).map_err(|e| e.to_string())?;
+    enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click).map_err(|e| e.to_string())?;
+    enigo.key(enigo::Key::Control, enigo::Direction::Release).map_err(|e| e.to_string())?;
+
+    std::thread::sleep(std::time::Duration::from_millis(120));
+
+    let text = window.clipboard().read_text().unwrap_or_default();
+    Ok(text)
+}
+```
+
+- **Step 2: Add bounded retry to mitigate clipboard race**
+
+If first read is empty, wait and try once more:
+
+```rust
+let mut text = window.clipboard().read_text().unwrap_or_default();
+if text.trim().is_empty() {
+    std::thread::sleep(std::time::Duration::from_millis(120));
+    text = window.clipboard().read_text().unwrap_or_default();
+}
+```
+
+- **Step 3: Surface failures as notifications**
+
+Use the existing notification plugin (`NotificationExt`) to show actionable feedback on:
+
+- synthetic copy failure
+- empty result after retries
+
+Expected messages:
+
+- “No selected text captured. Make sure the target app supports Ctrl+C.”
+- “Failed to read clipboard text.”
+- **Step 4: Commit**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "feat(linux-wayland): capture selection via Ctrl+C and clipboard"
+```
+
+## Task 3: Add `--selection` argv handling and single-instance forwarding
+
+**Files:**
+
+- Modify: `src-tauri/src/lib.rs`
+- **Step 1: Parse argv for `--selection`**
+
+Inside the single-instance callback `tauri_plugin_single_instance::init(|app, argv, _cwd| { ... })`:
+
+- detect `argv.iter().any(|a| a == "--selection")`
+- if present and `is_linux_wayland_session()` is true, call a handler.
+- **Step 2: Handle cold start (first instance)**
+
+Add startup-time argv read (from `std::env::args()` early in `run()` before `.run(...)`) and store a boolean like `startup_selection = ...`.
+
+After the app is ready (best place is after window exists), trigger the same handler if `startup_selection` is true.
+
+Implementation detail options (pick one and keep it simple):
+
+- Use `tauri::App::run` `RunEvent::Ready` or similar hook to ensure windows exist.
+- Or, in `setup` closure if already present in the project.
+- **Step 3: Implement the shared handler**
+
+Shared function (example):
+
+```rust
+fn handle_selection_trigger(app: &tauri::AppHandle) {
+    // 1) Get main window
+    // 2) Make sure it’s visible / focused if required by UX
+    // 3) Perform copy + clipboard read
+    // 4) Emit to frontend: "set-input" { text, mode: "selected" }
+}
+```
+
+Emit payload should match existing usage:
+
+- event name: `set-input`
+- payload shape: `{ text: string, mode: "selected" }`
+- **Step 4: Commit**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "feat(cli): handle typo --selection via single-instance argv"
+```
+
+## Task 4: Gate Typo internal global shortcut on Linux Wayland
+
+**Files:**
+
+- Modify: `src/shortcut.ts`
+- Modify: `src/App.vue`
+- **Step 1: Add a backend command for session info (if needed)**
+
+If frontend cannot reliably know Wayland session, add a Tauri command returning:
+
+- OS (`linux`, `macos`, `windows`)
+- `is_wayland` boolean (based on `is_linux_wayland_session()`)
+
+Example:
+
+```rust
+#[derive(serde::Serialize)]
+struct SessionInfo {
+    os: String,
+    is_wayland: bool,
+}
+
+#[tauri::command]
+fn get_session_info() -> SessionInfo {
+    SessionInfo {
+        os: std::env::consts::OS.to_string(),
+        is_wayland: is_linux_wayland_session(),
+    }
+}
+```
+
+- **Step 2: In `App.vue`, fetch session info on mount**
+
+Call `invoke('get_session_info')` and stash in a small store or module variable.
+
+- **Step 3: In `setupGlobalShortcut`, skip registering DEFAULT shortcut on Linux Wayland**
+
+Pseudo:
+
+```ts
+if (sessionInfo.os === 'linux' && sessionInfo.is_wayland) {
+  // still allow settings shortcut if desired, but do not depend on Ctrl+Shift+X
+  return
+}
+```
+
+- **Step 4: Commit**
+
+```bash
+git add src/App.vue src/shortcut.ts src-tauri/src/lib.rs
+git commit -m "feat(linux-wayland): prefer system shortcut over plugin global shortcut"
+```
+
+## Task 5: Update documentation for Linux Wayland system custom shortcut
+
+**Files:**
+
+- Modify: `README.md`
+- **Step 1: Add explicit steps**
+
+In the Wayland section, add:
+
+- path: `Settings -> Keyboard -> Custom Shortcuts`
+- command: `typo --selection`
+- keys: `Ctrl + Shift + X`
+- clarify this is only for Linux Wayland
+- **Step 2: Add troubleshooting notes**
+- selection empty → target app doesn’t support `Ctrl+C` or blocks synthetic events
+- clipboard read issues → ensure clipboard portal / permissions as needed
+- **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(linux-wayland): document system custom shortcut for typo --selection"
+```
+
+## Task 6: Verification (no regressions)
+
+**Files:**
+
+- N/A (commands only)
+- **Step 1: Build**
+
+Run: `pnpm install` (if needed)  
+Run: `pnpm dev` and/or `pnpm -C src-tauri tauri build`
+
+Expected:
+
+- App launches
+- No Rust compile errors
+- No TS build errors
+- **Step 2: Manual smoke tests**
+
+Linux Wayland:
+
+- Bind system shortcut to `typo --selection`
+- Test both “Typo running” and “Typo not running”
+
+Non-Wayland:
+
+- Verify existing `Ctrl/Cmd + Shift + X` still works as before
+- **Step 3: Final commit if any fixes**
+
+```bash
+git status
+```
+

--- a/docs/superpowers/specs/2026-04-14-wayland-selection-shortcut-design.md
+++ b/docs/superpowers/specs/2026-04-14-wayland-selection-shortcut-design.md
@@ -1,0 +1,131 @@
+# Typo Linux Wayland `--selection` Trigger Design
+
+## Context
+
+On Linux Wayland, Typo may not reliably receive global shortcuts in all applications.  
+The product needs a reliable Wayland path that lets users trigger Typo through the desktop environment's custom shortcut mechanism.
+
+This design applies only to Linux Wayland users.
+
+## Goals
+
+- Provide a stable user-trigger path for Linux Wayland via system custom shortcuts.
+- Expose a CLI entry `typo --selection`.
+- Reuse existing downstream Typo flow after text is obtained.
+- Keep existing behavior unchanged on non-Wayland platforms.
+
+## Non-goals
+
+- Replacing all existing global shortcut logic across all platforms.
+- Building compositor-specific integrations beyond system custom shortcuts.
+- Refactoring unrelated text processing or AI request logic.
+
+## User Experience
+
+### Target users
+
+Linux users running Wayland sessions.
+
+### Setup instructions (documentation)
+
+Typo documentation will explicitly guide users to:
+
+1. Open `Settings -> Keyboard -> Custom Shortcuts`
+2. Create a shortcut command: `typo --selection`
+3. Bind key: `Ctrl + Shift + X`
+
+### Runtime behavior
+
+- When users trigger the system shortcut, Typo executes `typo --selection`.
+- If Typo is already running, arguments are forwarded to the existing instance.
+- If Typo is not running, startup still processes `--selection` after initialization.
+
+## Platform gating
+
+`--selection` selection-capture behavior is active only when:
+
+- OS is Linux
+- Session is Wayland
+
+On other platforms/sessions, existing behavior remains unchanged.
+
+## Technical design
+
+### 1) Trigger entry and argument forwarding
+
+Use existing single-instance wiring to support both cases:
+
+- **Warm start**: second launch with `--selection` forwards argv to main instance.
+- **Cold start**: first launch reads startup argv and triggers the same handler.
+
+Define a shared handler (example name): `handle_selection_trigger`.
+
+### 2) Selection capture pipeline (Linux Wayland path)
+
+For Linux Wayland only, `handle_selection_trigger` runs:
+
+1. Simulate `Ctrl + C` key action.
+2. Wait a short delay (about 80-150ms) to allow clipboard updates.
+3. Read text from clipboard.
+4. Trim and validate text.
+5. If non-empty, send text into existing Typo downstream flow.
+
+This avoids relying on inaccessible direct selected-text APIs in problematic Wayland contexts.
+
+### 3) Frontend/global-shortcut behavior
+
+On Linux Wayland:
+
+- Do not rely on Typo's internal global shortcut as the main trigger path.
+- Users should use system custom shortcut with `typo --selection`.
+
+On non-Linux-Wayland:
+
+- Keep existing global shortcut registration and behavior.
+
+## Error handling
+
+- **Copy simulation failure**: log error and stop processing.
+- **Clipboard read failure**: show actionable message and stop processing.
+- **Empty clipboard text**: show "No selected text captured" style feedback.
+- **Unexpected argument state**: ignore safely with logs.
+
+## Compatibility and regression expectations
+
+- Linux Wayland: system shortcut path becomes reliable default.
+- Linux X11/macOS/Windows: no behavioral regression expected.
+- Existing text typing/paste and AI request flow remains unchanged.
+
+## Test plan
+
+### Manual validation
+
+1. **Linux Wayland + Typo already running**
+   - Trigger system shortcut bound to `typo --selection`.
+   - Verify selected text is captured and enters Typo flow.
+2. **Linux Wayland + Typo not running**
+   - Trigger system shortcut.
+   - Verify app starts and still executes `--selection`.
+3. **Linux non-Wayland**
+   - Verify existing shortcut path remains functional.
+4. **macOS/Windows**
+   - Smoke-check existing shortcut flow.
+5. **Error scenarios**
+   - No selection / clipboard unavailable / copy blocked.
+   - Verify clear feedback and no crash.
+
+## Risks and mitigations
+
+- **Risk**: Clipboard race after `Ctrl + C`.
+  - **Mitigation**: bounded delay and optional one retry read.
+- **Risk**: Some apps block synthetic key events.
+  - **Mitigation**: clear docs and user feedback when capture fails.
+- **Risk**: Session detection ambiguity.
+  - **Mitigation**: explicit Linux + Wayland checks and logging.
+
+## Rollout notes
+
+- Update README Wayland section with explicit setup steps and command.
+- Keep legacy notes for X11 fallback where still useful.
+- This design intentionally limits scope to Linux Wayland only.
+


### PR DESCRIPTION
## Summary
- add a design spec for Linux Wayland `typo --selection` behavior and constraints
- add an implementation plan with scoped tasks for runtime flow, shortcut gating, docs, and verification
- include `.worktrees/` in `.gitignore` to prevent local worktree pollution

## Test plan
- [x] Verify only the listed files are included in the commit
- [x] Confirm commit is on a new `cursor/` branch, not `main`
- [ ] Execute implementation tasks from the new plan in a follow-up PR

Made with [Cursor](https://cursor.com)