### PR TITLE
👷 Add CI workflow for cross-platform builds and Ubuntu shortcut script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,13 @@ jobs:
       - name: install frontend dependencies
         run: pnpm install
 
+      - uses: oNaiPs/secrets-to-env-action@v1
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       - name: build tauri app
         uses: tauri-apps/tauri-action@v0
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: --target aarch64-apple-darwin
+          - platform: macos-latest
+            args: --target x86_64-apple-darwin
+          - platform: ubuntu-22.04
+            args: ''
+          - platform: windows-latest
+            args: ''
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev
+
+      - name: install frontend dependencies
+        run: pnpm install
+
+      - name: build tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        with:
+          args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - name: setup node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ dist-ssr
 .env
 
 # Misc
-# TODO.md

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,10 @@
 # TODO
 
-- [ ] Refining the Interaction, Mac, Linux, Windows?
-- [ ] Add some logs for GUI client
-- [ ] Add server-side capabilities: Set up a Rails server and abstract the LLM API to the server?
-
----
-
-## Roadmap
-
-- [-] Update upgrade to system dialog confirmation
 - [ ] More settings available
 - [ ] Add system tray menu
 - [ ] Ctrl+1 to 5 for custom prompts
+
+---
+
+- [ ] Add some logs for GUI client
+- [ ] Add server-side capabilities: Set up a Rails server and abstract the LLM API to the server?

--- a/scripts/ubuntu-global-shortcut.sh
+++ b/scripts/ubuntu-global-shortcut.sh
@@ -14,6 +14,16 @@ while [[ "$#" -gt 0 ]]; do
         --local) MODE="local"; shift ;;
         --global) MODE="global"; shift ;;
         --binding|-b) BINDING="$2"; shift 2 ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --local          Set the shortcut command for local debug build"
+            echo "  --global         Set the shortcut command for global installation (default)"
+            echo "  --binding, -b    Specify the shortcut binding (default: <Control><Shift>x)"
+            echo "  --help, -h       Show this help message and exit"
+            exit 0
+            ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
 done
@@ -57,7 +67,7 @@ if [ -z "$NEW_KEY_PATH" ]; then
             fi
         done < <(echo "$current_bindings" | grep -o "'[^']*'")
         new_bindings+="'$NEW_KEY_PATH']"
-        
+
         gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "$new_bindings"
     fi
 fi

--- a/scripts/ubuntu-global-shortcut.sh
+++ b/scripts/ubuntu-global-shortcut.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Settings -> Keyboard -> Custom Shortcuts
+
+# Default values
+MODE="global"
+CMD="typo --selection"
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --local) MODE="local"; shift ;;
+        --global) MODE="global"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+done
+
+if [[ "$MODE" == "local" ]]; then
+    # Use absolute path for local debug build
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+    CMD="$REPO_ROOT/src-tauri/target/debug/typo --selection"
+fi
+
+# 1. Check if a shortcut named "Typo" already exists
+current_bindings=$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings)
+NEW_KEY_PATH=""
+
+# Convert ['path1', 'path2'] to a space-separated list of paths
+paths=$(echo "$current_bindings" | tr -d "[]'," | sed "s/@as //g")
+
+for p in $paths; do
+    # Remove potential single quotes
+    p=$(echo "$p" | tr -d "'")
+    if [ -n "$p" ]; then
+        name=$(gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$p name 2>/dev/null)
+        if [[ "$name" == "'Typo'" ]]; then
+            NEW_KEY_PATH=$p
+            break
+        fi
+    fi
+done
+
+# If not found, use default path and add it to the list
+if [ -z "$NEW_KEY_PATH" ]; then
+    NEW_KEY_PATH="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom-typo/"
+
+    # Add the new path to the system "master list"
+    if [[ "$current_bindings" != *"$NEW_KEY_PATH"* ]]; then
+        if [[ "$current_bindings" == "[]" || "$current_bindings" == "@as []" ]]; then
+            new_bindings="['$NEW_KEY_PATH']"
+        else
+            new_bindings="${current_bindings%]*}, '$NEW_KEY_PATH']"
+        fi
+        gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "$new_bindings"
+    fi
+fi
+
+# 2. Set/Update the specific properties of the shortcut
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH name "'Typo'"
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH command "'$CMD'"
+gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH binding "'<Control><Shift>x'"
+
+echo "Shortcut setup successfully ($NEW_KEY_PATH) [$MODE mode]:"
+echo "  Binding: Ctrl + Shift + X"
+echo "  Command: $CMD"

--- a/scripts/ubuntu-global-shortcut.sh
+++ b/scripts/ubuntu-global-shortcut.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
+set -euo pipefail
 
 # Settings -> Keyboard -> Custom Shortcuts
 
 # Default values
 MODE="global"
 CMD="typo --selection"
+BINDING="<Control><Shift>x"
 
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --local) MODE="local"; shift ;;
         --global) MODE="global"; shift ;;
+        --binding|-b) BINDING="$2"; shift 2 ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
 done
@@ -26,20 +29,18 @@ fi
 current_bindings=$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings)
 NEW_KEY_PATH=""
 
-# Convert ['path1', 'path2'] to a space-separated list of paths
-paths=$(echo "$current_bindings" | tr -d "[]'," | sed "s/@as //g")
-
-for p in $paths; do
-    # Remove potential single quotes
+# Extract the quoted strings and iterate over them safely using a while loop
+while read -r p; do
+    # Remove single quotes
     p=$(echo "$p" | tr -d "'")
     if [ -n "$p" ]; then
-        name=$(gsettings get org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$p name 2>/dev/null)
+        name=$(gsettings get "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$p" name 2>/dev/null || true)
         if [[ "$name" == "'Typo'" ]]; then
             NEW_KEY_PATH=$p
             break
         fi
     fi
-done
+done < <(echo "$current_bindings" | grep -o "'[^']*'")
 
 # If not found, use default path and add it to the list
 if [ -z "$NEW_KEY_PATH" ]; then
@@ -47,20 +48,25 @@ if [ -z "$NEW_KEY_PATH" ]; then
 
     # Add the new path to the system "master list"
     if [[ "$current_bindings" != *"$NEW_KEY_PATH"* ]]; then
-        if [[ "$current_bindings" == "[]" || "$current_bindings" == "@as []" ]]; then
-            new_bindings="['$NEW_KEY_PATH']"
-        else
-            new_bindings="${current_bindings%]*}, '$NEW_KEY_PATH']"
-        fi
+        # Reconstruct the bindings list safely
+        new_bindings="["
+        while read -r p; do
+            p=$(echo "$p" | tr -d "'")
+            if [ -n "$p" ]; then
+                new_bindings+="'$p', "
+            fi
+        done < <(echo "$current_bindings" | grep -o "'[^']*'")
+        new_bindings+="'$NEW_KEY_PATH']"
+        
         gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "$new_bindings"
     fi
 fi
 
 # 2. Set/Update the specific properties of the shortcut
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH name "'Typo'"
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH command "'$CMD'"
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH binding "'<Control><Shift>x'"
+gsettings set "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH" name "'Typo'"
+gsettings set "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH" command "\"$CMD\""
+gsettings set "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$NEW_KEY_PATH" binding "'$BINDING'"
 
 echo "Shortcut setup successfully ($NEW_KEY_PATH) [$MODE mode]:"
-echo "  Binding: Ctrl + Shift + X"
+echo "  Binding: $BINDING"
 echo "  Command: $CMD"


### PR DESCRIPTION
## Summary
- Setup a new CI workflow (`ci.yml`) to run cross-platform builds for macOS, Ubuntu, and Windows on pushes and PRs.
- Address missing signing secret errors in the `ci.yml` build by properly exposing GitHub secrets context.
- Update `pnpm` action setup configuration in the workflows.
- Introduce an Ubuntu global shortcut setup script (`scripts/ubuntu-global-shortcut.sh`) for mapping GNOME custom keybindings.
- Ensure the shortcut script parses `gsettings` robustly, safely sanitizes paths, and supports a `--help` options flag.
- Assorted cleanups to the uncompleted tasks in `TODO.md`.

## Test plan
- [ ] Verify GitHub Actions runners build the Tauri app successfully across environments.
- [ ] Run `./scripts/ubuntu-global-shortcut.sh --help` locally.
- [ ] Optionally run `./scripts/ubuntu-global-shortcut.sh --local` on a GNOME desktop to verify it avoids parse issues on `gsettings`.
