### PR TITLE
🌐 Implement localized release notes in desktop upgrade window and push script

### DIFF
--- a/apps/desktop/src/windows/Upgrade.vue
+++ b/apps/desktop/src/windows/Upgrade.vue
@@ -13,14 +13,12 @@ const isUpgrading = ref(false)
 const downloadProgress = ref(0)
 
 const notes = computed(() => {
-  if (updateInfo.value) {
-    const rawJson = updateInfo.value.rawJson as any
-    if (rawJson?.notes_i18n) {
-      return rawJson.notes_i18n[locale.value] || updateInfo.value.body || t('upgrade.no_notes')
-    }
-    return updateInfo.value.body || t('upgrade.no_notes')
-  }
-  return ''
+  const info = updateInfo.value
+  if (!info)
+    return ''
+
+  const i18nNotes = (info.rawJson as any)?.notes_i18n
+  return i18nNotes?.[locale.value] || info.body || t('upgrade.no_notes')
 })
 
 async function onUpgradeConfirm() {

--- a/apps/desktop/src/windows/Upgrade.vue
+++ b/apps/desktop/src/windows/Upgrade.vue
@@ -1,16 +1,27 @@
 <script setup lang="ts">
 import { relaunch } from '@tauri-apps/plugin-process'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Button } from '@/components/ui/button'
 import UpgradeProgress from '@/components/UpgradeProgress.vue'
 import { useGlobalState } from '@/composables/useGlobalState'
 import { useI18n } from '@/composables/useI18n'
 
 const { updateInfo, setCurrentWindow } = useGlobalState()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 const isUpgrading = ref(false)
 const downloadProgress = ref(0)
+
+const notes = computed(() => {
+  if (updateInfo.value) {
+    const rawJson = updateInfo.value.rawJson as any
+    if (rawJson?.notes_i18n) {
+      return rawJson.notes_i18n[locale.value] || updateInfo.value.body || t('upgrade.no_notes')
+    }
+    return updateInfo.value.body || t('upgrade.no_notes')
+  }
+  return ''
+})
 
 async function onUpgradeConfirm() {
   if (updateInfo.value) {
@@ -49,7 +60,7 @@ function onCancel() {
         {{ t('upgrade.title', { version: updateInfo?.version }) }}
       </h1>
       <p class="text-sm text-gray-300 whitespace-pre-wrap">
-        {{ updateInfo?.body || t('upgrade.no_notes') }}
+        {{ notes }}
       </p>
     </div>
     <div class="flex justify-end gap-3 mt-6">

--- a/packages/releases/src/pull.ts
+++ b/packages/releases/src/pull.ts
@@ -124,7 +124,7 @@ async function main() {
 
     const filePath = path.join(DATA_DIR, `${tag}.json`)
     const notesPath = path.join(DATA_DIR, `${tag}.release.notes`)
-    
+
     await ensureDir(DATA_DIR)
     await writeJson(filePath, data)
 

--- a/packages/releases/src/push.ts
+++ b/packages/releases/src/push.ts
@@ -74,6 +74,7 @@ async function main() {
 
       // Update GitHub latest.json's notes field from LOCAL json's notes.en
       latestJson.notes = data.notes
+      latestJson.notes_i18n = data.notes_i18n
 
       await writeJson(latestJsonPath, latestJson)
 


### PR DESCRIPTION
## Summary
- Use `notes_i18n` in the desktop `Upgrade.vue` window to display localized release notes based on the user's current locale.
- Update the `releases/push.ts` script to correctly sync `notes_i18n` data from the local release JSON to the remote `latest.json`.

## Test plan
- [ ] Verified that `Upgrade.vue` correctly pulls localized notes when available in `rawJson`.
- [ ] Checked that `push.ts` includes `notes_i18n` in the updated `latest.json`.