### PR TITLE
✨ [desktop]: Implement deep link prompt import functionality

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -297,6 +297,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +567,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -591,6 +615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +650,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1158,6 +1197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,8 +1742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1699,9 +1755,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1884,6 +1942,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2104,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2070,9 +2148,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2389,6 +2469,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2656,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3606,6 +3702,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,8 +3980,10 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3838,8 +3992,10 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3936,6 +4092,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3962,6 +4119,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3998,6 +4156,7 @@ version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4554,6 +4713,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5184,6 +5364,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,6 +5666,7 @@ dependencies = [
  "enigo 0.6.1",
  "get-selected-text",
  "macos-accessibility-client",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
@@ -5883,6 +6079,16 @@ name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -672,6 +672,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1063,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1870,6 +1899,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -3019,6 +3054,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,6 +3871,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4728,6 +4783,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94deb2e2e4641514ac496db2cddcfc850d6fc9d51ea17b82292a0490bd20ba5b"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5089,6 +5165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5391,6 +5476,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-deep-link",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -6121,6 +6207,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-process = "2"
 tokio = { version = "1.52.0", features = ["time"] }
+reqwest = { version = "0.13", features = ["json"] }
 
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["macos-private-api", "devtools", "tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 get-selected-text = "0.1.6"
@@ -33,7 +35,6 @@ tokio = { version = "1.52.0", features = ["time"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2"
-tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/apps/desktop/src-tauri/capabilities/desktop.json
+++ b/apps/desktop/src-tauri/capabilities/desktop.json
@@ -13,6 +13,7 @@
     "global-shortcut:allow-is-registered",
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",
+    "global-shortcut:allow-unregister-all",
     "core:app:allow-app-hide",
     "core:app:allow-app-show",
     "updater:default"

--- a/apps/desktop/src-tauri/src/cli.rs
+++ b/apps/desktop/src-tauri/src/cli.rs
@@ -23,7 +23,7 @@ pub fn handle_single_instance_event(
     is_wayland: bool,
     selection_handler: fn(&tauri::AppHandle),
 ) {
-    use tauri::Manager;
+    use tauri::{Manager, Emitter};
 
     if has_version_flag(argv.iter().map(|arg| arg.as_str())) {
         println!("typo {}", env!("CARGO_PKG_VERSION"));
@@ -33,6 +33,13 @@ pub fn handle_single_instance_event(
     if has_selection_flag(argv.iter().map(|arg| arg.as_str())) && is_wayland {
         selection_handler(app);
         return;
+    }
+
+    // Handle deep links in single instance
+    for arg in argv {
+        if arg.starts_with("typo://") {
+            let _ = app.emit("deep-link://link", vec![arg.clone()]);
+        }
     }
 
     if let Some(window) = app.get_webview_window("main") {

--- a/apps/desktop/src-tauri/src/cli.rs
+++ b/apps/desktop/src-tauri/src/cli.rs
@@ -37,7 +37,8 @@ pub fn handle_single_instance_event(
 
     // Handle deep links in single instance
     for arg in argv {
-        if arg.starts_with("typo://") {
+        if arg.starts_with("typo://") || arg.starts_with("typo:") {
+            println!("Single instance deep link detected: {}", arg);
             let _ = app.emit("deep-link://link", vec![arg.clone()]);
         }
     }

--- a/apps/desktop/src-tauri/src/cli.rs
+++ b/apps/desktop/src-tauri/src/cli.rs
@@ -37,8 +37,7 @@ pub fn handle_single_instance_event(
 
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.show();
-        // TODO: option in settings
-        // let _ = window.set_focus();
+        let _ = window.set_focus();
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -167,6 +167,24 @@ fn consume_deep_link() -> Option<String> {
     }
 }
 
+#[tauri::command]
+async fn fetch_remote_prompt(id: String) -> Result<serde_json::Value, String> {
+    let url = format!("https://typo.yuler.cc/prompts/{}.json", id);
+    let client = reqwest::Client::new();
+    let response = client.get(url).send().await.map_err(|e| e.to_string())?;
+
+    if !response.status().is_success() {
+        return Err(format!("Failed to fetch: {}", response.status()));
+    }
+
+    let data = response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(data)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let startup_selection = cli::has_selection_flag(std::env::args());
@@ -227,6 +245,7 @@ pub fn run() {
             keyboard::keyboard_paste_text,
             consume_pending_selection_input,
             consume_deep_link,
+            fetch_remote_prompt,
             tray::update_tray_menu,
         ])
         .run(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -226,7 +226,8 @@ pub fn run() {
             #[cfg(target_os = "linux")]
             {
                 for arg in std::env::args() {
-                    if arg.starts_with("typo://") {
+                    if arg.starts_with("typo://") || arg.starts_with("typo:") {
+                        println!("Initial deep link detected: {}", arg);
                         if let Ok(mut pending) = pending_deep_link().lock() {
                             *pending = Some(arg);
                         }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -171,6 +171,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             cli::handle_single_instance_event(
                 app,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -71,6 +71,11 @@ fn pending_selection_payload() -> &'static Mutex<Option<SetInputPayload>> {
     PENDING_SELECTION_PAYLOAD.get_or_init(|| Mutex::new(None))
 }
 
+fn pending_deep_link() -> &'static Mutex<Option<String>> {
+    static PENDING_DEEP_LINK: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+    PENDING_DEEP_LINK.get_or_init(|| Mutex::new(None))
+}
+
 fn app_cli_selection_trigger(app: &tauri::AppHandle) {
     println!("app_cli_selection_trigger");
 
@@ -154,6 +159,14 @@ fn set_pending_selection_input(payload: SetInputPayload) {
     }
 }
 
+#[tauri::command]
+fn consume_deep_link() -> Option<String> {
+    match pending_deep_link().lock() {
+        Ok(mut pending) => pending.take(),
+        Err(_) => None,
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let startup_selection = cli::has_selection_flag(std::env::args());
@@ -190,6 +203,19 @@ pub fn run() {
             if startup_selection && in_linux_wayland() {
                 app_cli_startup_selection_trigger(&app.handle());
             }
+
+            // Handle initial deep link on Linux
+            #[cfg(target_os = "linux")]
+            {
+                for arg in std::env::args() {
+                    if arg.starts_with("typo://") {
+                        if let Ok(mut pending) = pending_deep_link().lock() {
+                            *pending = Some(arg);
+                        }
+                    }
+                }
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -200,6 +226,7 @@ pub fn run() {
             keyboard::keyboard_select_all,
             keyboard::keyboard_paste_text,
             consume_pending_selection_input,
+            consume_deep_link,
             tray::update_tray_menu,
         ])
         .run(tauri::generate_context!())

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "typo",
-  "identifier": "cc.yuler.typo",
+  "identifier": "com.typo.app",
   "build": {
     "beforeDevCommand": "pnpm dev:frontend",
     "devUrl": "http://localhost:1420",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "typo",
-  "identifier": "com.typo.app",
   "build": {
     "beforeDevCommand": "pnpm dev:frontend",
     "devUrl": "http://localhost:1420",
@@ -27,6 +26,11 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "schemes": [
+        "typo"
+      ]
+    },
     "updater": {
       "active": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI4MjJCQTgwM0EyNEUyMjIKUldRaTRpUTZnTG9pdUFKSEJIZ3JnMG5Oay8zYVZjWW9rWisya2x3T2JhY1JsbnFvYzhqeDFsUFEK",
@@ -39,6 +43,7 @@
     }
   },
   "bundle": {
+    "identifier": "cc.yuler.typo",
     "active": true,
     "linux": {
       "deb": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "typo",
+  "identifier": "cc.yuler.typo",
   "build": {
     "beforeDevCommand": "pnpm dev:frontend",
     "devUrl": "http://localhost:1420",
@@ -43,7 +44,6 @@
     }
   },
   "bundle": {
-    "identifier": "cc.yuler.typo",
     "active": true,
     "linux": {
       "deb": {

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -3,7 +3,7 @@ import type { UnlistenFn } from '@tauri-apps/api/event'
 import type { CurrentWindow } from '@/composables/useGlobalState'
 import type { SystemInfo } from '@/types'
 import { invoke } from '@tauri-apps/api/core'
-import { listen } from '@tauri-apps/api/event'
+import { emit, listen } from '@tauri-apps/api/event'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification'
 import { check } from '@tauri-apps/plugin-updater'
@@ -99,6 +99,8 @@ async function handleImportSuccess(data: any) {
 
   await set('slash_commands', commands)
   await save()
+
+  await emit('refresh-settings')
 
   sendNotification({
     title: 'typo',

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -130,25 +130,43 @@ onUnmounted(() => {
 })
 
 function handleDeepLink(urlStr: string) {
+  console.log('[DeepLink] Processing:', urlStr)
   try {
-    const url = new URL(urlStr)
-    const isImportAction = url.host === 'import-prompt' || url.pathname.includes('import-prompt')
-    const id = url.searchParams.get('id')
+    let id: string | null = null
+    let isImportAction = false
+
+    try {
+      const url = new URL(urlStr)
+      isImportAction = url.host === 'import-prompt' || url.pathname.includes('import-prompt')
+      id = url.searchParams.get('id')
+    }
+    catch (e) {
+      console.warn('[DeepLink] URL parsing failed, trying manual match:', e)
+      // Fallback for non-standard URL formats like typo:import-prompt?id=xxx
+      if (urlStr.includes('import-prompt')) {
+        isImportAction = true
+        const match = urlStr.match(/[?&]id=([^&]+)/)
+        if (match)
+          id = match[1]
+      }
+    }
+
+    console.log('[DeepLink] Parse result:', { isImportAction, id })
 
     if (isImportAction && id) {
-      console.log('Detected import-prompt ID:', id)
       importId.value = id
       setSettingsTab('prompts')
       if (currentWindow.value !== 'Settings') {
+        console.log('[DeepLink] Switching to Settings window')
         setCurrentWindow('Settings')
       }
     }
     else {
-      console.warn('Deep link matched protocol but not action/id:', { isImportAction, id })
+      console.warn('[DeepLink] No valid action or ID found in URL')
     }
   }
-  catch (e) {
-    console.error('Failed to parse deep-link URL:', e)
+  catch (err) {
+    console.error('[DeepLink] Fatal error processing link:', err)
   }
 }
 

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -124,6 +124,28 @@ onUnmounted(() => {
   trayUnlisteners.length = 0
 })
 
+function handleDeepLink(urlStr: string) {
+  try {
+    const url = new URL(urlStr)
+    const isImportAction = url.host === 'import-prompt' || url.pathname.includes('import-prompt')
+    const id = url.searchParams.get('id')
+
+    if (isImportAction && id) {
+      console.log('Detected import-prompt ID:', id)
+      importId.value = id
+      if (currentWindow.value !== 'Main') {
+        setCurrentWindow('Main')
+      }
+    }
+    else {
+      console.warn('Deep link matched protocol but not action/id:', { isImportAction, id })
+    }
+  }
+  catch (e) {
+    console.error('Failed to parse deep-link URL:', e)
+  }
+}
+
 onMounted(async () => {
   const appWindow = WebviewWindow.getCurrent()
   await appWindow?.setVisibleOnAllWorkspaces(true)
@@ -143,22 +165,18 @@ onMounted(async () => {
 
   trayUnlisteners.push(await listen<string[]>('deep-link://link', (event) => {
     const payload = event.payload
-    if (payload.length > 0) {
-      try {
-        const url = new URL(payload[0])
-        if (url.protocol === 'typo:' && url.host === 'import-prompt') {
-          const id = url.searchParams.get('id')
-          if (id) {
-            console.log('Detected import-prompt ID:', id)
-            importId.value = id
-          }
-        }
-      }
-      catch (e) {
-        console.error('Failed to parse deep-link URL:', e)
-      }
+    console.log('Deep link received:', payload)
+    if (payload && payload.length > 0) {
+      handleDeepLink(payload[0])
     }
   }))
+
+  // Check for pending deep link on startup
+  const pendingUrl = await invoke<string | null>('consume_deep_link')
+  if (pendingUrl) {
+    console.log('Consuming pending deep link:', pendingUrl)
+    handleDeepLink(pendingUrl)
+  }
 
   void checkUpgrade()
 

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -130,43 +130,31 @@ onUnmounted(() => {
 })
 
 function handleDeepLink(urlStr: string) {
-  console.log('[DeepLink] Processing:', urlStr)
+  // eslint-disable-next-line no-console
+  console.debug('[DeepLink] Processing:', urlStr)
+
   try {
     let id: string | null = null
-    let isImportAction = false
 
-    try {
-      const url = new URL(urlStr)
-      isImportAction = url.host === 'import-prompt' || url.pathname.includes('import-prompt')
-      id = url.searchParams.get('id')
-    }
-    catch (e) {
-      console.warn('[DeepLink] URL parsing failed, trying manual match:', e)
-      // Fallback for non-standard URL formats like typo:import-prompt?id=xxx
-      if (urlStr.includes('import-prompt')) {
-        isImportAction = true
-        const match = urlStr.match(/[?&]id=([^&]+)/)
-        if (match)
-          id = match[1]
-      }
+    // Extremely permissive parsing: just look for id= value
+    const match = urlStr.match(/[?&]id=([^&]+)/)
+    if (match) {
+      id = match[1]
     }
 
-    console.log('[DeepLink] Parse result:', { isImportAction, id })
+    const isImportAction = urlStr.includes('import-prompt')
+
+    // eslint-disable-next-line no-console
+    console.debug('[DeepLink] Results:', { id, isImportAction })
 
     if (isImportAction && id) {
       importId.value = id
       setSettingsTab('prompts')
-      if (currentWindow.value !== 'Settings') {
-        console.log('[DeepLink] Switching to Settings window')
-        setCurrentWindow('Settings')
-      }
-    }
-    else {
-      console.warn('[DeepLink] No valid action or ID found in URL')
+      setCurrentWindow('Settings')
     }
   }
   catch (err) {
-    console.error('[DeepLink] Fatal error processing link:', err)
+    console.error('[DeepLink] Error:', err)
   }
 }
 
@@ -192,7 +180,8 @@ onMounted(async () => {
 
   trayUnlisteners.push(await listen<string[]>('deep-link://link', (event) => {
     const payload = event.payload
-    console.log('Deep link received:', payload)
+    // eslint-disable-next-line no-alert
+    window.alert(`Deep link received in JS: ${JSON.stringify(payload)}`)
     if (payload && payload.length > 0) {
       handleDeepLink(payload[0])
     }
@@ -201,6 +190,7 @@ onMounted(async () => {
   // Check for pending deep link on startup
   const pendingUrl = await invoke<string | null>('consume_deep_link')
   if (pendingUrl) {
+    // eslint-disable-next-line no-console
     console.log('Consuming pending deep link:', pendingUrl)
     handleDeepLink(pendingUrl)
   }

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -7,7 +7,8 @@ import { listen } from '@tauri-apps/api/event'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification'
 import { check } from '@tauri-apps/plugin-updater'
-import { nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import DeepLinkImportModal from '@/components/DeepLinkImportModal.vue'
 import Navbar from '@/components/Navbar.vue'
 import Ribbon from '@/components/Ribbon.vue'
 import Window from '@/components/Window.vue'
@@ -22,6 +23,7 @@ const { currentWindow, setCurrentWindow, setUpdateInfo } = useGlobalState()
 const { t } = useI18n()
 const isDev = import.meta.env.DEV
 const trayUnlisteners: UnlistenFn[] = []
+const importId = ref<string | null>(null)
 
 async function notifyUpToDate() {
   try {
@@ -72,6 +74,10 @@ function onChangeWindow(window: CurrentWindow) {
   setCurrentWindow(window)
 }
 
+function handleImportSuccess(data: any) {
+  console.log('Successfully imported data:', data)
+}
+
 watch(() => currentWindow.value, async () => {
   if (currentWindow.value === 'Main') {
     await nextTick()
@@ -119,6 +125,7 @@ onMounted(async () => {
           const id = url.searchParams.get('id')
           if (id) {
             console.log('Detected import-prompt ID:', id)
+            importId.value = id
           }
         }
       }
@@ -144,6 +151,12 @@ onMounted(async () => {
     <Navbar v-if="currentWindow !== 'Main'" data-tauri-drag-region @settings="() => onChangeWindow('Settings')" />
     <Window class="flex-1" />
     <Ribbon v-if="isDev" />
+    <DeepLinkImportModal
+      v-if="importId"
+      :id="importId"
+      @close="importId = null"
+      @success="handleImportSuccess"
+    />
   </main>
 </template>
 

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -110,6 +110,24 @@ onMounted(async () => {
     }
   }))
 
+  trayUnlisteners.push(await listen<string[]>('deep-link://link', (event) => {
+    const payload = event.payload
+    if (payload.length > 0) {
+      try {
+        const url = new URL(payload[0])
+        if (url.protocol === 'typo:' && url.host === 'import-prompt') {
+          const id = url.searchParams.get('id')
+          if (id) {
+            console.log('Detected import-prompt ID:', id)
+          }
+        }
+      }
+      catch (e) {
+        console.error('Failed to parse deep-link URL:', e)
+      }
+    }
+  }))
+
   void checkUpgrade()
 
   const systemInfo = await invoke<SystemInfo>('get_system_info')

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -15,7 +15,7 @@ import Window from '@/components/Window.vue'
 import { useGlobalState } from '@/composables/useGlobalState'
 import { initializeI18n, useI18n } from '@/composables/useI18n'
 import { setupGlobalShortcut } from '@/shortcut'
-import { initializeStore } from '@/store'
+import { get, initializeStore, save, set } from '@/store'
 import { syncTrayMenu } from '@/tray'
 import { initializeWindow, setupMainWindow, setupSettingsWindow, setupUpgradeWindow } from '@/window'
 
@@ -74,8 +74,33 @@ function onChangeWindow(window: CurrentWindow) {
   setCurrentWindow(window)
 }
 
-function handleImportSuccess(data: any) {
-  console.log('Successfully imported data:', data)
+async function handleImportSuccess(data: any) {
+  const { metadata, content } = data
+  if (!metadata || !content)
+    return
+
+  const commands = [...await get('slash_commands')]
+  const newCommand = {
+    id: metadata.id,
+    key: `/${metadata.id}`,
+    value: content,
+  }
+
+  const index = commands.findIndex(c => c.id === metadata.id || c.key === newCommand.key)
+  if (index > -1) {
+    commands[index] = newCommand
+  }
+  else {
+    commands.push(newCommand)
+  }
+
+  await set('slash_commands', commands)
+  await save()
+
+  sendNotification({
+    title: 'typo',
+    body: t('import.success'),
+  })
 }
 
 watch(() => currentWindow.value, async () => {

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -19,7 +19,7 @@ import { get, initializeStore, save, set } from '@/store'
 import { syncTrayMenu } from '@/tray'
 import { initializeWindow, setupMainWindow, setupSettingsWindow, setupUpgradeWindow } from '@/window'
 
-const { currentWindow, setCurrentWindow, setUpdateInfo } = useGlobalState()
+const { currentWindow, setCurrentWindow, setSettingsTab, setUpdateInfo } = useGlobalState()
 const { t } = useI18n()
 const isDev = import.meta.env.DEV
 const trayUnlisteners: UnlistenFn[] = []
@@ -71,6 +71,9 @@ async function checkUpgrade(options?: { verbose?: boolean }) {
 }
 
 function onChangeWindow(window: CurrentWindow) {
+  if (window === 'Settings') {
+    setSettingsTab('basic')
+  }
   setCurrentWindow(window)
 }
 
@@ -133,8 +136,9 @@ function handleDeepLink(urlStr: string) {
     if (isImportAction && id) {
       console.log('Detected import-prompt ID:', id)
       importId.value = id
-      if (currentWindow.value !== 'Main') {
-        setCurrentWindow('Main')
+      setSettingsTab('prompts')
+      if (currentWindow.value !== 'Settings') {
+        setCurrentWindow('Settings')
       }
     }
     else {
@@ -155,7 +159,10 @@ onMounted(async () => {
   initializeWindow()
   await syncTrayMenu()
 
-  trayUnlisteners.push(await listen('tray:open-settings', () => setCurrentWindow('Settings')))
+  trayUnlisteners.push(await listen('tray:open-settings', () => {
+    setSettingsTab('basic')
+    setCurrentWindow('Settings')
+  }))
   trayUnlisteners.push(await listen('tray:check-updates', () => void checkUpgrade({ verbose: true })))
   trayUnlisteners.push(await listen('set-input', () => {
     if (currentWindow.value !== 'Main') {

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -76,7 +76,7 @@ function onChangeWindow(window: CurrentWindow) {
 
 async function handleImportSuccess(data: any) {
   const { metadata, content } = data
-  if (!metadata || !content)
+  if (!metadata?.id || !content)
     return
 
   const commands = [...await get('slash_commands')]

--- a/apps/desktop/src/components/DeepLinkImportModal.vue
+++ b/apps/desktop/src/components/DeepLinkImportModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -30,11 +31,7 @@ async function handleImport() {
   loading.value = true
   error.value = null
   try {
-    const response = await fetch(`https://typo.yuler.cc/prompts/${encodeURIComponent(props.id)}.json`)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch: ${response.statusText}`)
-    }
-    const data = await response.json()
+    const data = await invoke('fetch_remote_prompt', { id: props.id })
     emit('success', data)
     emit('close')
   }

--- a/apps/desktop/src/components/DeepLinkImportModal.vue
+++ b/apps/desktop/src/components/DeepLinkImportModal.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Loader2 } from 'lucide-vue-next'
+
+const props = defineProps<{
+  id: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'success', data: any): void
+}>()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+async function handleImport() {
+  loading.value = true
+  error.value = null
+  try {
+    const response = await fetch(`https://typo.yuler.cc/prompts/${props.id}.json`)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.statusText}`)
+    }
+    const data = await response.json()
+    emit('success', data)
+    emit('close')
+  }
+  catch (err: any) {
+    error.value = err.message || 'Unknown error'
+  }
+  finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <AlertDialog :open="true" @update:open="(open) => !open && emit('close')">
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>Detect new prompt</AlertDialogTitle>
+        <AlertDialogDescription>
+          ID: {{ id }}
+          <div v-if="error" class="text-destructive mt-2">
+            Error: {{ error }}
+          </div>
+          <div v-else class="mt-2">
+            Import it?
+          </div>
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel :disabled="loading" @click="emit('close')">
+          Cancel
+        </AlertDialogCancel>
+        <AlertDialogAction :disabled="loading" @click="handleImport">
+          <Loader2 v-if="loading" class="mr-2 h-4 w-4 animate-spin" />
+          {{ loading ? 'Importing...' : 'Import' }}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+</template>

--- a/apps/desktop/src/components/DeepLinkImportModal.vue
+++ b/apps/desktop/src/components/DeepLinkImportModal.vue
@@ -11,6 +11,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { Loader2 } from 'lucide-vue-next'
+import { useI18n } from '@/composables/useI18n'
 
 const props = defineProps<{
   id: string
@@ -21,6 +22,7 @@ const emit = defineEmits<{
   (e: 'success', data: any): void
 }>()
 
+const { t } = useI18n()
 const loading = ref(false)
 const error = ref<string | null>(null)
 
@@ -37,7 +39,7 @@ async function handleImport() {
     emit('close')
   }
   catch (err: any) {
-    error.value = err.message || 'Unknown error'
+    error.value = err.message || t('import.error')
   }
   finally {
     loading.value = false
@@ -49,24 +51,23 @@ async function handleImport() {
   <AlertDialog :open="true" @update:open="(open) => !open && emit('close')">
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogTitle>Detect new prompt</AlertDialogTitle>
+        <AlertDialogTitle>{{ t('import.title') }}</AlertDialogTitle>
         <AlertDialogDescription>
-          ID: {{ id }}
           <div v-if="error" class="text-destructive mt-2">
-            Error: {{ error }}
+            {{ t('import.error') }}: {{ error }}
           </div>
           <div v-else class="mt-2">
-            Import it?
+            {{ t('import.description', { id: props.id }) }}
           </div>
         </AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>
         <AlertDialogCancel :disabled="loading" @click="emit('close')">
-          Cancel
+          {{ t('import.cancel') }}
         </AlertDialogCancel>
         <AlertDialogAction :disabled="loading" @click="handleImport">
           <Loader2 v-if="loading" class="mr-2 h-4 w-4 animate-spin" />
-          {{ loading ? 'Importing...' : 'Import' }}
+          {{ t('import.confirm') }}
         </AlertDialogAction>
       </AlertDialogFooter>
     </AlertDialogContent>

--- a/apps/desktop/src/components/DeepLinkImportModal.vue
+++ b/apps/desktop/src/components/DeepLinkImportModal.vue
@@ -30,7 +30,7 @@ async function handleImport() {
   loading.value = true
   error.value = null
   try {
-    const response = await fetch(`https://typo.yuler.cc/prompts/${props.id}.json`)
+    const response = await fetch(`https://typo.yuler.cc/prompts/${encodeURIComponent(props.id)}.json`)
     if (!response.ok) {
       throw new Error(`Failed to fetch: ${response.statusText}`)
     }

--- a/apps/desktop/src/components/DeepLinkImportModal.vue
+++ b/apps/desktop/src/components/DeepLinkImportModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
+import { Loader2 } from 'lucide-vue-next'
+import { ref } from 'vue'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,7 +12,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { Loader2 } from 'lucide-vue-next'
 import { useI18n } from '@/composables/useI18n'
 
 const props = defineProps<{

--- a/apps/desktop/src/composables/useGlobalState.ts
+++ b/apps/desktop/src/composables/useGlobalState.ts
@@ -24,6 +24,8 @@ export const useGlobalState = createGlobalState(() => {
   return {
     currentWindow,
     setCurrentWindow,
+    settingsTab,
+    setSettingsTab,
     updateInfo,
     setUpdateInfo,
   }

--- a/apps/desktop/src/composables/useGlobalState.ts
+++ b/apps/desktop/src/composables/useGlobalState.ts
@@ -3,11 +3,17 @@ import { createGlobalState } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
 export type CurrentWindow = 'Main' | 'Settings' | 'Upgrade' | 'None'
+export type SettingsTab = 'basic' | 'prompts'
 
 export const useGlobalState = createGlobalState(() => {
   const currentWindow = shallowRef<CurrentWindow>('Main')
   const setCurrentWindow = (window: CurrentWindow) => {
     currentWindow.value = window
+  }
+
+  const settingsTab = shallowRef<SettingsTab>('basic')
+  const setSettingsTab = (tab: SettingsTab) => {
+    settingsTab.value = tab
   }
 
   const updateInfo = shallowRef<Update | null>(null)

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -47,5 +47,11 @@
   "tray.check_updates": "Check for updates",
   "tray.about": "About typo v{version}",
   "tray.quit": "Quit typo",
-  "updates.up_to_date": "You're on the latest version (v{version})"
+  "updates.up_to_date": "You're on the latest version (v{version})",
+  "import.title": "Import Prompt",
+  "import.description": "Detect new prompt (ID: {id}), import it?",
+  "import.confirm": "Confirm",
+  "import.cancel": "Cancel",
+  "import.success": "Prompt imported successfully",
+  "import.error": "Failed to fetch prompt"
 }

--- a/apps/desktop/src/locales/jp.json
+++ b/apps/desktop/src/locales/jp.json
@@ -47,5 +47,11 @@
   "tray.check_updates": "アップデートを確認",
   "tray.about": "typo について v{version}",
   "tray.quit": "typo を終了",
-  "updates.up_to_date": "最新版です (v{version})"
+  "updates.up_to_date": "最新版です (v{version})",
+  "import.title": "プロンプトをインポート",
+  "import.description": "新しいプロンプト (ID: {id}) を検出しました。インポートしますか？",
+  "import.confirm": "確認",
+  "import.cancel": "キャンセル",
+  "import.success": "プロンプトが正常にインポートされました",
+  "import.error": "プロンプトの取得に失敗しました"
 }

--- a/apps/desktop/src/locales/zh.json
+++ b/apps/desktop/src/locales/zh.json
@@ -47,5 +47,11 @@
   "tray.check_updates": "检查更新",
   "tray.about": "关于 typo v{version}",
   "tray.quit": "退出 typo",
-  "updates.up_to_date": "已是最新版本 (v{version})"
+  "updates.up_to_date": "已是最新版本 (v{version})",
+  "import.title": "导入提示词",
+  "import.description": "检测到新的提示词 (ID: {id})，是否导入？",
+  "import.confirm": "确认导入",
+  "import.cancel": "取消",
+  "import.success": "提示词已成功导入",
+  "import.error": "获取提示词失败"
 }

--- a/apps/desktop/src/windows/Main.vue
+++ b/apps/desktop/src/windows/Main.vue
@@ -15,7 +15,7 @@ import * as store from '@/store'
 import { formatShortcut, sleep } from '@/utils'
 
 const appWindow = getCurrentWindow()
-const { setCurrentWindow } = useGlobalState()
+const { setCurrentWindow, setSettingsTab } = useGlobalState()
 const { t } = useI18n()
 
 type CapsuleState = 'idle' | 'processing' | 'result' | 'error'
@@ -214,6 +214,7 @@ async function onESC() {
 }
 
 function gotoSettings() {
+  setSettingsTab('basic')
   setCurrentWindow('Settings')
 }
 </script>

--- a/apps/desktop/src/windows/Settings.vue
+++ b/apps/desktop/src/windows/Settings.vue
@@ -17,11 +17,8 @@ import { DEFAULT_GLOBAL_SHORTCUT } from '@/store'
 import * as store from '@/store'
 import { formatShortcut } from '@/utils'
 
-const { setCurrentWindow } = useGlobalState()
+const { setCurrentWindow, settingsTab: activeTab } = useGlobalState()
 
-type SettingsTab = 'basic' | 'prompts'
-
-const activeTab = ref<SettingsTab>('basic')
 const showApiKey = ref(false)
 
 const { locale, setLocale, t } = useI18n()

--- a/apps/desktop/src/windows/Settings.vue
+++ b/apps/desktop/src/windows/Settings.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Locale } from '@typo/languages'
 import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
 import { localeNames, locales } from '@typo/languages'
 import { EyeIcon, EyeOffIcon, PlusIcon, RotateCcwIcon, SaveIcon, Trash2Icon } from 'lucide-vue-next'
 import { nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -10,7 +11,6 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
-import { listen } from '@tauri-apps/api/event'
 import { useGlobalState } from '@/composables/useGlobalState'
 import { useI18n } from '@/composables/useI18n'
 import { setupGlobalShortcut, unregisterCurrentGlobalShortcut } from '@/shortcut'
@@ -28,6 +28,18 @@ const { locale, setLocale, t } = useI18n()
 async function onLocaleChange(next: Locale) {
   await setLocale(next)
 }
+
+const isMacOS = ref(false)
+
+const form = ref({
+  autoselect: false,
+  ai_provider: 'deepseek' as store.AI_PROVIDER,
+  deepseek_api_key: '',
+  ollama_model: '',
+  system_prompt: '',
+  slash_commands: [] as store.SlashCommand[],
+  global_shortcut: '',
+})
 
 async function loadSettings() {
   form.value.autoselect = await store.get('autoselect')
@@ -48,21 +60,11 @@ async function loadSettings() {
   }
 }
 
-const form = ref({
-  autoselect: false,
-  ai_provider: 'deepseek' as store.AI_PROVIDER,
-  deepseek_api_key: '',
-  ollama_model: '',
-  system_prompt: '',
-  slash_commands: [] as store.SlashCommand[],
-  global_shortcut: '',
-})
-
 const ollamaModels = ref<any[]>([])
 
 const isCapturingShortcut = ref(false)
 const shortcutConflictError = ref('')
-const isMacOS = ref(false)
+
 const captureButtonEl = ref<HTMLElement | null>(null)
 const pressedCaptureKeys = new Set<string>()
 const recordedCaptureKeys = new Set<string>()

--- a/apps/desktop/src/windows/Settings.vue
+++ b/apps/desktop/src/windows/Settings.vue
@@ -10,6 +10,7 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { listen } from '@tauri-apps/api/event'
 import { useGlobalState } from '@/composables/useGlobalState'
 import { useI18n } from '@/composables/useI18n'
 import { setupGlobalShortcut, unregisterCurrentGlobalShortcut } from '@/shortcut'
@@ -20,11 +21,31 @@ import { formatShortcut } from '@/utils'
 const { setCurrentWindow, settingsTab: activeTab } = useGlobalState()
 
 const showApiKey = ref(false)
+const unlisteners: (() => void)[] = []
 
 const { locale, setLocale, t } = useI18n()
 
 async function onLocaleChange(next: Locale) {
   await setLocale(next)
+}
+
+async function loadSettings() {
+  form.value.autoselect = await store.get('autoselect')
+  form.value.deepseek_api_key = await store.get('deepseek_api_key')
+  form.value.ai_provider = await store.get('ai_provider')
+  form.value.ollama_model = await store.get('ollama_model')
+  form.value.system_prompt = await store.get('ai_system_prompt')
+  form.value.global_shortcut = await store.get('global_shortcut') || DEFAULT_GLOBAL_SHORTCUT
+
+  const systemInfo = await invoke<{ os: string, is_wayland: boolean }>('get_system_info')
+  isMacOS.value = systemInfo.os === 'macos'
+
+  const shortcuts = await store.get('slash_commands')
+  form.value.slash_commands = shortcuts.map(s => ({ ...s, id: s.id || crypto.randomUUID() }))
+
+  if (form.value.ai_provider === 'ollama') {
+    await loadOllamaModels()
+  }
 }
 
 const form = ref({
@@ -186,22 +207,11 @@ async function loadOllamaModels() {
 }
 
 onMounted(async () => {
-  form.value.autoselect = await store.get('autoselect')
-  form.value.deepseek_api_key = await store.get('deepseek_api_key')
-  form.value.ai_provider = await store.get('ai_provider')
-  form.value.ollama_model = await store.get('ollama_model')
-  form.value.system_prompt = await store.get('ai_system_prompt')
-  form.value.global_shortcut = await store.get('global_shortcut') || DEFAULT_GLOBAL_SHORTCUT
+  await loadSettings()
 
-  const systemInfo = await invoke<{ os: string, is_wayland: boolean }>('get_system_info')
-  isMacOS.value = systemInfo.os === 'macos'
-
-  const shortcuts = await store.get('slash_commands')
-  form.value.slash_commands = shortcuts.map(s => ({ ...s, id: s.id || crypto.randomUUID() }))
-
-  if (form.value.ai_provider === 'ollama') {
-    await loadOllamaModels()
-  }
+  unlisteners.push(await listen('refresh-settings', async () => {
+    await loadSettings()
+  }))
 
   nextTick(() => {
     const textarea = document.getElementById('system_prompt') as HTMLTextAreaElement
@@ -216,6 +226,9 @@ onUnmounted(() => {
   // Clean up keydown listener if component is unmounted while capturing shortcut
   if (isCapturingShortcut.value) {
     stopCapture()
+  }
+  for (const unlisten of unlisteners) {
+    unlisten()
   }
 })
 

--- a/apps/www/public/prompts/english-polisher.json
+++ b/apps/www/public/prompts/english-polisher.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0",
+  "type": "prompt",
+  "metadata": {
+    "id": "english-polisher",
+    "title": "English Polisher",
+    "description": "Expert English writing and translation assistant"
+  },
+  "content": "You are an expert English writing and translation assistant with native-level proficiency.\nYour task is to improve and polish English text, including translating Chinese content and fixing errors.\n\nCORE RESPONSIBILITIES:\n1. Convert Chinese text into natural, idiomatic English\n2. Fix all grammar, spelling, and punctuation mistakes\n3. Enhance readability through better sentence structure and flow\n4. Ensure the text sounds authentically native while keeping the original meaning\n5. Match writing style to the context (formal/casual/technical)\n\nKEY RULES:\n- Return ONLY the improved text - no explanations or comments\n- Keep the original meaning and tone intact\n- Write clearly and concisely\n- Follow standard English grammar and conventions\n- Make it sound natural and native\n- Maintain technical terms and proper names exactly\n- Mirror the original text's formatting\n\nOUT FORMAT:\nSimply provide the corrected text without any additional notes or commentary.\n\nINPUT FORMAT:\nThe text to improve will be provided in the user message between ### markers:\n\n### Input\n(The input text will be here)\n###"
+}

--- a/docs/linux-deep-link-setup.md
+++ b/docs/linux-deep-link-setup.md
@@ -46,15 +46,15 @@ xdg-open "typo://import-prompt?id=english-polisher"
 
 ## 常见问题排查
 
-1.  **"The specified location is not supported"**:
-    *   检查 `.desktop` 文件是否位于 `~/.local/share/applications/` 目录下。
-    *   检查 `MimeType` 行末尾是否有分号 `;`。
-    *   确保运行了 `update-desktop-database`。
-2.  **App 启动了但没有处理数据**:
-    *   确保 `Exec` 路径后面带有 `%u`。
-    *   确保你正在运行的是开发版单实例模式（Tauri v2 默认处理）。
-3.  **路径无效**:
-    *   如果你移动了项目目录，必须更新 `.desktop` 文件中的 `Exec` 绝对路径。
+1. **"The specified location is not supported"**:
+   - 检查 `.desktop` 文件是否位于 `~/.local/share/applications/` 目录下。
+   - 检查 `MimeType` 行末尾是否有分号 `;`。
+   - 确保运行了 `update-desktop-database`。
+2. **App 启动了但没有处理数据**:
+   - 确保 `Exec` 路径后面带有 `%u`。
+   - 确保你正在运行的是开发版单实例模式（Tauri v2 默认处理）。
+3. **路径无效**:
+   - 如果你移动了项目目录，必须更新 `.desktop` 文件中的 `Exec` 绝对路径。
 
 ## 生产环境说明
 

--- a/docs/linux-deep-link-setup.md
+++ b/docs/linux-deep-link-setup.md
@@ -1,0 +1,61 @@
+# Linux Deep Link 开发环境配置指南
+
+在 Linux (如 Ubuntu, Debian, Arch 等) 开发环境下，系统不会像 macOS 或 Windows 那样在开发阶段自动关联自定义协议（如 `typo://`）。为了使浏览器或终端能够拉起开发中的 Tauri App，需要手动进行 MIME 注册。
+
+## 1. 创建桌面入口文件 (`.desktop`)
+
+在 Linux 中，协议关联是基于 `.desktop` 文件的。你需要创建一个指向你当前项目开发二进制文件的桌面文件。
+
+创建文件 `~/.local/share/applications/typo-dev.desktop`：
+
+```ini
+[Desktop Entry]
+Name=Typo Dev
+# 注意：Exec 必须使用绝对路径，并且结尾必须带有 %u 以接收 URL 参数
+Exec=/home/yourname/path/to/typo/apps/desktop/src-tauri/target/debug/typo %u
+Type=Application
+Terminal=false
+MimeType=x-scheme-handler/typo;
+Categories=Utility;
+```
+
+> **提示**：你可以运行 `pwd` 获取当前项目根目录，确保 `Exec` 路径正确。
+
+## 2. 注册协议关联
+
+执行以下命令通知系统处理 `typo://` 协议：
+
+```bash
+# 1. 设置默认处理器
+xdg-mime default typo-dev.desktop x-scheme-handler/typo
+
+# 2. 刷新桌面数据库
+update-desktop-database ~/.local/share/applications
+
+# 3. 验证关联是否成功 (应该输出 typo-dev.desktop)
+gio mime x-scheme-handler/typo
+```
+
+## 3. 测试拉起功能
+
+你可以通过以下命令测试系统是否能够识别并拉起 App：
+
+```bash
+xdg-open "typo://import-prompt?id=english-polisher"
+```
+
+## 常见问题排查
+
+1.  **"The specified location is not supported"**:
+    *   检查 `.desktop` 文件是否位于 `~/.local/share/applications/` 目录下。
+    *   检查 `MimeType` 行末尾是否有分号 `;`。
+    *   确保运行了 `update-desktop-database`。
+2.  **App 启动了但没有处理数据**:
+    *   确保 `Exec` 路径后面带有 `%u`。
+    *   确保你正在运行的是开发版单实例模式（Tauri v2 默认处理）。
+3.  **路径无效**:
+    *   如果你移动了项目目录，必须更新 `.desktop` 文件中的 `Exec` 绝对路径。
+
+## 生产环境说明
+
+当你通过 `.deb` 包分发应用时，Tauri 的打包工具会自动处理上述所有步骤，用户安装后即可直接使用，无需手动配置。此指南仅针对**开发调试阶段**。

--- a/docs/superpowers/plans/2026-04-22-deep-link-import.md
+++ b/docs/superpowers/plans/2026-04-22-deep-link-import.md
@@ -1,0 +1,162 @@
+# Deep Link 提示词导入实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现通过 `typo://import-prompt?id=xxx` 链接从 `typo.yuler.cc` 导入提示词到 App。
+
+**Architecture:** 利用 Tauri v2 的 `deep-link` 插件捕获系统协议，通过 `single-instance` 确保单实例运行，并在前端 Vue 应用中监听事件并触发确认弹窗及数据抓取逻辑。
+
+**Tech Stack:** Tauri v2 (Rust), Vue 3 (TypeScript), Fetch API.
+
+---
+
+### Task 1: 基础设施配置 (Rust)
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/Cargo.toml`
+- Modify: `apps/desktop/src-tauri/tauri.conf.json`
+
+- [ ] **Step 1: 添加 Rust 依赖**
+
+在 `apps/desktop/src-tauri/Cargo.toml` 中添加插件：
+```toml
+[dependencies]
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = "2"
+```
+
+- [ ] **Step 2: 配置 Deep Link 协议**
+
+修改 `apps/desktop/src-tauri/tauri.conf.json`，确保 `identifier` 正确并配置 `deepLink`：
+```json
+{
+  "bundle": {
+    "identifier": "cc.yuler.typo"
+  },
+  "plugins": {
+    "deep-link": {
+      "schemes": ["typo"]
+    }
+  }
+}
+```
+
+- [ ] **Step 3: 提交更改**
+```bash
+git add apps/desktop/src-tauri/Cargo.toml apps/desktop/src-tauri/tauri.conf.json
+git commit -m "chore: add deep-link and single-instance plugins configuration"
+```
+
+---
+
+### Task 2: 插件初始化与单实例设置 (Rust)
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: 在 lib.rs 中注册插件**
+
+```rust
+// apps/desktop/src-tauri/src/lib.rs
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            let _ = app.get_webview_window("main")
+                .expect("no main window")
+                .set_focus();
+        }))
+        // ... 其他插件
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+- [ ] **Step 2: 验证编译**
+运行 `pnpm tauri build --no-bundle` (或 dev 模式) 确保插件正确集成。
+
+- [ ] **Step 3: 提交更改**
+```bash
+git add apps/desktop/src-tauri/src/lib.rs
+git commit -m "feat: initialize deep-link and single-instance in rust"
+```
+
+---
+
+### Task 3: 前端全局监听器实现 (Vue)
+
+**Files:**
+- Modify: `apps/desktop/src/App.vue`
+
+- [ ] **Step 1: 编写 Deep Link 监听逻辑**
+
+在 `App.vue` 中添加监听代码：
+```typescript
+import { onMounted } from 'vue';
+import { listen } from '@tauri-apps/api/event';
+
+onMounted(async () => {
+  await listen('deep-link://link', (event) => {
+    const urls = event.payload as string[];
+    const url = new URL(urls[0]);
+    if (url.protocol === 'typo:' && url.host === 'import-prompt') {
+      const id = url.searchParams.get('id');
+      if (id) {
+        // 触发弹窗逻辑 (将在下一步实现)
+        console.log('Detected import-prompt with ID:', id);
+      }
+    }
+  });
+});
+```
+
+- [ ] **Step 2: 提交更改**
+```bash
+git add apps/desktop/src/App.vue
+git commit -m "feat: add deep-link event listener in frontend"
+```
+
+---
+
+### Task 4: 确认导入弹窗与数据抓取
+
+**Files:**
+- Create: `apps/desktop/src/components/DeepLinkImportModal.vue`
+- Modify: `apps/desktop/src/App.vue`
+
+- [ ] **Step 1: 创建弹窗组件逻辑**
+
+```vue
+<!-- apps/desktop/src/components/DeepLinkImportModal.vue -->
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const props = defineProps<{ id: string }>();
+const emit = defineEmits(['close', 'success']);
+
+const loading = ref(false);
+
+async function handleConfirm() {
+  loading.value = true;
+  try {
+    const response = await fetch(`https://typo.yuler.cc/prompts/${props.id}.json`);
+    const data = await response.json();
+    // 执行导入逻辑 (例如存入 Store)
+    emit('success', data);
+  } catch (error) {
+    console.error('Failed to fetch prompt:', error);
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+```
+
+- [ ] **Step 2: 集成到 App.vue 并测试**
+在 `App.vue` 中引用该组件，并在监听到事件时显示。
+
+- [ ] **Step 3: 提交更改**
+```bash
+git add apps/desktop/src/components/DeepLinkImportModal.vue apps/desktop/src/App.vue
+git commit -m "feat: implement import confirmation modal and data fetching"
+```

--- a/docs/superpowers/specs/2026-04-22-deep-link-import-design.md
+++ b/docs/superpowers/specs/2026-04-22-deep-link-import-design.md
@@ -1,0 +1,57 @@
+# Deep Link 提示词导入功能设计文档
+
+## 1. 概述
+本设计方案旨在为 Typo 桌面端应用（Tauri v2）增加 Deep Link 支持，允许用户通过点击 Web 端的链接（如 `typo://import-prompt?id=123`）直接在 App 中导入提示词。
+
+## 2. 核心流程
+1.  **协议捕获**：系统识别 `typo://` 协议并将 URL 传递给已运行的 Typo 实例。
+2.  **事件转发**：Tauri Rust 层通过 `tauri-plugin-deep-link` 拦截 URL，并触发前端事件。
+3.  **解析与确认**：
+    *   前端解析参数，提取 `id`。
+    *   弹出全局对话框，询问用户是否导入。
+4.  **数据抓取**：用户确认后，App 请求 `https://typo.yuler.cc/prompts/{id}.json` 获取数据。
+5.  **导入执行**：将获取到的提示词内容保存至本地存储并给予反馈。
+
+## 3. 技术实现细节
+
+### 3.1 基础设施 (Rust 层)
+*   **插件集成**：
+    *   `tauri-plugin-deep-link`: 负责注册和监听系统层级的 Deep Link。
+    *   `tauri-plugin-single-instance`: 确保 Deep Link 触发时激活现有窗口，而不是启动新实例。
+*   **配置**：在 `tauri.conf.json` 中配置 `bundle > identifier` 和对应的协议方案。
+
+### 3.2 协议定义
+*   **Scheme**: `typo`
+*   **Action**: `import-prompt`
+*   **示例 URL**: `typo://import-prompt?id=p123`
+
+### 3.3 数据结构 (JSON)
+App 将从 `https://typo.yuler.cc/prompts/{id}.json` 下载以下格式的数据：
+```json
+{
+  "version": "1.0",
+  "type": "prompt",
+  "metadata": {
+    "id": "p123",
+    "title": "中英翻译助手",
+    "description": "专业的学术论文翻译提示词"
+  },
+  "content": "你现在是一名专业的学术翻译官..."
+}
+```
+
+### 3.4 前端实现 (Vue 3)
+*   **全局监听器**：在 `App.vue` 的 `onMounted` 钩子中使用 `listen('deep-link://link', ...)`（由插件提供）。
+*   **交互逻辑**：
+    *   解析 URL 参数。
+    *   调用 `Dialog` 或 `Modal` 组件展示确认框。
+    *   使用 `fetch` 获取远程数据。
+    *   成功后使用 `tauri-plugin-notification` 提醒用户。
+
+## 4. 安全考虑
+*   **用户确认**：所有通过外部链接触发的写入操作必须经过用户手动点击“确认”。
+*   **域名白名单**：App 仅从 `typo.yuler.cc` 获取数据，防止恶意链接诱导 App 下载第三方非法内容。
+*   **输入校验**：对获取到的 JSON 内容进行格式校验，确保不包含恶意脚本。
+
+## 5. 后续扩展
+*   **登录同步**：未来可扩展 `action=auth` 流程，通过相同机制实现 Web 扫码登录后的 App 状态注入。


### PR DESCRIPTION
## Summary
- Implemented deep link support using `tauri-plugin-deep-link` and `tauri-plugin-single-instance`.
- Added frontend listener for `typo://import-prompt?id=xxx` deep links.
- Created `DeepLinkImportModal` for user confirmation before importing.
- Implemented data fetching from `typo.yuler.cc` with persistence to local store.
- Added i18n support for English, Chinese, and Japanese.
- Included design specification and implementation plan.

## Test plan
- [ ] Manual test: Trigger `typo://import-prompt?id=test` and verify modal appearance and data import.
- [ ] Verify single instance behavior: Clicking a link when app is closed vs open.