### PR TITLE
✨ [core]: Implement magic link email templates and configure SMTP delivery

### DIFF
--- a/core/app/mailers/application_mailer.rb
+++ b/core/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("MAILER_FROM", "Typo <hi@yuler.cc>")
+  default from: ENV.fetch("MAILER_FROM", "Typo <support@example.com>")
 
   layout "mailer"
 end

--- a/core/app/mailers/application_mailer.rb
+++ b/core/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAILER_FROM", "Typo <hi@yuler.cc>")
+
   layout "mailer"
 end

--- a/core/app/mailers/application_mailer.rb
+++ b/core/app/mailers/application_mailer.rb
@@ -1,5 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("MAILER_FROM", "Typo <support@example.com>")
+  SUPPORT_EMAIL = ENV.fetch("SUPPORT_EMAIL", "support@example.com")
+  default from: ENV.fetch("MAILER_FROM", "Typo <#{SUPPORT_EMAIL}>")
 
   layout "mailer"
 end

--- a/core/app/mailers/magic_link_mailer.rb
+++ b/core/app/mailers/magic_link_mailer.rb
@@ -2,7 +2,7 @@ class MagicLinkMailer < ApplicationMailer
   def sign_in_instructions(magic_link)
     @magic_link = magic_link
     @identity = @magic_link.identity
-    @support_email = ENV.fetch("SUPPORT_EMAIL", "support@example.com")
+    @support_email = SUPPORT_EMAIL
 
     mail to: @identity.email, subject: "Your sign in code is: #{ @magic_link.code }"
   end

--- a/core/app/mailers/magic_link_mailer.rb
+++ b/core/app/mailers/magic_link_mailer.rb
@@ -2,6 +2,7 @@ class MagicLinkMailer < ApplicationMailer
   def sign_in_instructions(magic_link)
     @magic_link = magic_link
     @identity = @magic_link.identity
+    @support_email = ENV.fetch("SUPPORT_EMAIL", "support@example.com")
 
     mail to: @identity.email, subject: "Your sign in code is: #{ @magic_link.code }"
   end

--- a/core/app/models/account.rb
+++ b/core/app/models/account.rb
@@ -3,7 +3,7 @@ class Account < ApplicationRecord
   has_many :identities, through: :users
 
   validates :name, presence: true
-  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9-_]+\z/ },
+  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9\-_]+\z/ },
                     exclusion: { in: AccountSlug::RESERVED_SLUGS, message: "is reserved" }
 
   before_validation :set_slug_from_name, on: :create

--- a/core/app/models/account.rb
+++ b/core/app/models/account.rb
@@ -4,7 +4,8 @@ class Account < ApplicationRecord
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9\-_]+\z/ },
-                    exclusion: { in: AccountSlug::RESERVED_SLUGS, message: "is reserved" }
+                    exclusion: { in: AccountSlug::RESERVED_SLUGS, message: "is reserved" },
+                    length: { maximum: 32 }
 
   before_validation :set_slug_from_name, on: :create
   # before_create :only_single_personal_account_allowed

--- a/core/app/models/account.rb
+++ b/core/app/models/account.rb
@@ -3,9 +3,9 @@ class Account < ApplicationRecord
   has_many :identities, through: :users
 
   validates :name, presence: true
-  validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9\-_]+\z/ },
+  validates :slug, presence: true, uniqueness: true, format: { with: AccountSlug::FORMAT },
                     exclusion: { in: AccountSlug::RESERVED_SLUGS, message: "is reserved" },
-                    length: { in: 4..16 }
+                    length: { in: AccountSlug::LENGTH }
 
   before_validation :set_slug_from_name, on: :create
   # before_create :only_single_personal_account_allowed

--- a/core/app/models/account.rb
+++ b/core/app/models/account.rb
@@ -5,7 +5,7 @@ class Account < ApplicationRecord
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true, format: { with: /\A[a-z0-9\-_]+\z/ },
                     exclusion: { in: AccountSlug::RESERVED_SLUGS, message: "is reserved" },
-                    length: { maximum: 32 }
+                    length: { in: 4..16 }
 
   before_validation :set_slug_from_name, on: :create
   # before_create :only_single_personal_account_allowed

--- a/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
@@ -1,0 +1,8 @@
+<h1>Welcome to Typo!</h1>
+<p>Please enter this 6-character verification code on the Typo sign-in page:</p>
+
+<strong><%= @magic_link.code %></strong>
+
+<p>This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.</p>
+
+<p class="footer">Need help? <%= mail_to "hi@yuler.cc", "Send us an email"%>.</p>

--- a/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
@@ -5,4 +5,4 @@
 
 <p>This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.</p>
 
-<p class="footer">Need help? <%= mail_to "hi@yuler.cc", "Send us an email"%>.</p>
+<p class="footer">Need help? <%= mail_to ENV.fetch("SUPPORT_EMAIL", "support@example.com"), "Send us an email" %>.</p>

--- a/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
@@ -3,6 +3,6 @@
 
 <strong><%= @magic_link.code %></strong>
 
-<p>This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.</p>
+<p>This code will work for <%= distance_of_time_in_words(0, MagicLink::EXPIRATION_TIME) %>.</p>
 
 <p class="footer">Need help? <%= mail_to @support_email, "Send us an email" %>.</p>

--- a/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.html.erb
@@ -5,4 +5,4 @@
 
 <p>This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.</p>
 
-<p class="footer">Need help? <%= mail_to ENV.fetch("SUPPORT_EMAIL", "support@example.com"), "Send us an email" %>.</p>
+<p class="footer">Need help? <%= mail_to @support_email, "Send us an email" %>.</p>

--- a/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
@@ -1,0 +1,9 @@
+Welcome to Typo!
+
+Please enter this 6-character verification code on the Typo sign-in page.
+
+<%= @magic_link.code %>
+
+This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.
+
+Need help? mail to hi@yuler.cc

--- a/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
@@ -6,4 +6,4 @@ Please enter this 6-character verification code on the Typo sign-in page.
 
 This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.
 
-Need help? mail to hi@yuler.cc
+Need help? mail to <%= ENV.fetch("SUPPORT_EMAIL", "support@example.com") %>

--- a/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
@@ -4,6 +4,6 @@ Please enter this 6-character verification code on the Typo sign-in page.
 
 <%= @magic_link.code %>
 
-This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.
+This code will work for <%= distance_of_time_in_words(0, MagicLink::EXPIRATION_TIME) %>.
 
 Need help? Contact us at <%= @support_email %>

--- a/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
+++ b/core/app/views/magic_link_mailer/sign_in_instructions.text.erb
@@ -6,4 +6,4 @@ Please enter this 6-character verification code on the Typo sign-in page.
 
 This code will work for <%= distance_of_time_in_words(MagicLink::EXPIRATION_TIME) %>.
 
-Need help? mail to <%= ENV.fetch("SUPPORT_EMAIL", "support@example.com") %>
+Need help? Contact us at <%= @support_email %>

--- a/core/config/environments/production.rb
+++ b/core/config/environments/production.rb
@@ -64,14 +64,14 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              ENV.fetch("SMTP_ADDRESS", "smtp.example.com"),
-    port:                 ENV.fetch("SMTP_PORT", 587).to_i,
+    port:                 ENV.fetch("SMTP_PORT", (ENV["SMTP_SSL_ENABLED"] == "true" ? 465 : 587)).to_i,
     domain:               ENV.fetch("SMTP_DOMAIN", "example.com"),
     user_name:            ENV["SMTP_USERNAME"].presence,
     password:             ENV["SMTP_PASSWORD"].presence,
-    authentication:       (ENV["SMTP_AUTHENTICATION"].presence || "plain").to_sym,
-    enable_starttls_auto: true,
+    authentication:       ENV["SMTP_AUTHENTICATION"].presence&.to_sym || (:plain if ENV["SMTP_USERNAME"].present?),
+    enable_starttls_auto: ENV["SMTP_SSL_ENABLED"] != "true",
     tls:                  ENV["SMTP_SSL_ENABLED"] == "true"
-  }
+  }.compact
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/core/config/environments/production.rb
+++ b/core/config/environments/production.rb
@@ -58,16 +58,21 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("SITE_DOMAIN", "example.com") }
+  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM", "hi@yuler.cc") }
 
-  # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
-  # config.action_mailer.smtp_settings = {
-  #   user_name: Rails.application.credentials.dig(:smtp, :user_name),
-  #   password: Rails.application.credentials.dig(:smtp, :password),
-  #   address: "smtp.example.com",
-  #   port: 587,
-  #   authentication: :plain
-  # }
+  # Specify outgoing SMTP server.
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV.fetch("SMTP_ADDRESS", "smtp.example.com"),
+    port:                 ENV.fetch("SMTP_PORT", 587).to_i,
+    domain:               ENV.fetch("SMTP_DOMAIN", "example.com"),
+    user_name:            ENV.fetch("SMTP_USERNAME", nil),
+    password:             ENV.fetch("SMTP_PASSWORD", nil),
+    authentication:       "plain",
+    enable_starttls_auto: true,
+    tls:                  ENV.fetch("SMTP_SSL_ENABLED", "false") == "true"
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/core/config/environments/production.rb
+++ b/core/config/environments/production.rb
@@ -59,7 +59,6 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: ENV.fetch("SITE_DOMAIN", "example.com") }
-  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM", "support@example.com") }
 
   # Specify outgoing SMTP server.
   config.action_mailer.delivery_method = :smtp
@@ -67,11 +66,11 @@ Rails.application.configure do
     address:              ENV.fetch("SMTP_ADDRESS", "smtp.example.com"),
     port:                 ENV.fetch("SMTP_PORT", 587).to_i,
     domain:               ENV.fetch("SMTP_DOMAIN", "example.com"),
-    user_name:            ENV.fetch("SMTP_USERNAME", nil),
-    password:             ENV.fetch("SMTP_PASSWORD", nil),
-    authentication:       ENV.fetch("SMTP_AUTHENTICATION", "plain"),
+    user_name:            ENV["SMTP_USERNAME"].presence,
+    password:             ENV["SMTP_PASSWORD"].presence,
+    authentication:       (ENV["SMTP_AUTHENTICATION"].presence || "plain").to_sym,
     enable_starttls_auto: true,
-    tls:                  ENV.fetch("SMTP_SSL_ENABLED", "false") == "true"
+    tls:                  ENV["SMTP_SSL_ENABLED"] == "true"
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/core/config/environments/production.rb
+++ b/core/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: ENV.fetch("SITE_DOMAIN", "example.com") }
-  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM", "hi@yuler.cc") }
+  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM", "support@example.com") }
 
   # Specify outgoing SMTP server.
   config.action_mailer.delivery_method = :smtp
@@ -69,7 +69,7 @@ Rails.application.configure do
     domain:               ENV.fetch("SMTP_DOMAIN", "example.com"),
     user_name:            ENV.fetch("SMTP_USERNAME", nil),
     password:             ENV.fetch("SMTP_PASSWORD", nil),
-    authentication:       "plain",
+    authentication:       ENV.fetch("SMTP_AUTHENTICATION", "plain"),
     enable_starttls_auto: true,
     tls:                  ENV.fetch("SMTP_SSL_ENABLED", "false") == "true"
   }

--- a/core/config/environments/production.rb
+++ b/core/config/environments/production.rb
@@ -63,9 +63,9 @@ Rails.application.configure do
   # Specify outgoing SMTP server.
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:              ENV.fetch("SMTP_ADDRESS", "smtp.example.com"),
-    port:                 ENV.fetch("SMTP_PORT", (ENV["SMTP_SSL_ENABLED"] == "true" ? 465 : 587)).to_i,
-    domain:               ENV.fetch("SMTP_DOMAIN", "example.com"),
+    address:              ENV["SMTP_ADDRESS"].presence || "smtp.example.com",
+    port:                 ENV["SMTP_PORT"].presence&.to_i || (ENV["SMTP_SSL_ENABLED"] == "true" ? 465 : 587),
+    domain:               ENV["SMTP_DOMAIN"].presence || "example.com",
     user_name:            ENV["SMTP_USERNAME"].presence,
     password:             ENV["SMTP_PASSWORD"].presence,
     authentication:       ENV["SMTP_AUTHENTICATION"].presence&.to_sym || (:plain if ENV["SMTP_USERNAME"].present?),

--- a/core/config/initializers/account_slug.rb
+++ b/core/config/initializers/account_slug.rb
@@ -1,5 +1,7 @@
 module AccountSlug
   PATTERN = /([a-zA-Z0-9_-]{4,16})/
+  FORMAT = /\A[a-z0-9\-_]+\z/
+  LENGTH = 4..16
   PATH_INFO_MATCH = /\A(\/#{AccountSlug::PATTERN})/
   RESERVED_SLUGS = %w[session dashboard onboarding admin api assets billing help jobs login logout magic_link rails settings setup static support typo]
 

--- a/core/test/mailers/previews/magic_link_mailer_preview.rb
+++ b/core/test/mailers/previews/magic_link_mailer_preview.rb
@@ -1,0 +1,9 @@
+class MagicLinkMailerPreview < ActionMailer::Preview
+  def magic_link
+    identity = Identity.all.sample
+    magic_link = MagicLink.new(identity: identity)
+    magic_link.valid?
+
+    MagicLinkMailer.sign_in_instructions(magic_link)
+  end
+end

--- a/core/test/mailers/previews/magic_link_mailer_preview.rb
+++ b/core/test/mailers/previews/magic_link_mailer_preview.rb
@@ -1,6 +1,6 @@
 class MagicLinkMailerPreview < ActionMailer::Preview
   def magic_link
-    identity = Identity.all.sample
+    identity = Identity.all.sample || Identity.new(email: "user@example.com")
     magic_link = MagicLink.new(identity: identity)
     magic_link.valid?
 


### PR DESCRIPTION
## Summary
- Added HTML and text templates for the magic link sign-in email.
- Implemented `MagicLinkMailerPreview` for easy local testing.
- Configured production mailer to use environment variables for SMTP settings and default host.
- Fixed regex warning in `Account` model slug validation.

## Test plan
- [x] Verified email templates render correctly in `MagicLinkMailerPreview`.
- [x] Confirmed configuration matches required environment variable names (SMTP, SITE_DOMAIN, MAILER_FROM).