### PR TITLE
✨ [core]: Add recurring job for stale magic link cleanup

### DIFF
--- a/core/config/recurring.yml
+++ b/core/config/recurring.yml
@@ -12,8 +12,8 @@
 production:
   clear_solid_queue_finished_jobs:
     command: 'SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)'
-    schedule: every hour at minute 12
+    schedule: every day at 00:00
 
   cleanup_magic_links:
     command: 'MagicLink.cleanup'
-    schedule: every 4 hours at minute 25
+    schedule: every day at 00:00

--- a/core/config/recurring.yml
+++ b/core/config/recurring.yml
@@ -12,8 +12,8 @@
 production:
   clear_solid_queue_finished_jobs:
     command: 'SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)'
-    schedule: every day at 00:00
+    schedule: every day at 00:10
 
   cleanup_magic_links:
     command: 'MagicLink.cleanup'
-    schedule: every day at 00:00
+    schedule: every day at 00:20

--- a/core/config/recurring.yml
+++ b/core/config/recurring.yml
@@ -13,3 +13,7 @@ production:
   clear_solid_queue_finished_jobs:
     command: 'SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)'
     schedule: every hour at minute 12
+
+  cleanup_magic_links:
+    command: "MagicLink.cleanup"
+    schedule: every 4 hours

--- a/core/config/recurring.yml
+++ b/core/config/recurring.yml
@@ -15,5 +15,5 @@ production:
     schedule: every hour at minute 12
 
   cleanup_magic_links:
-    command: "MagicLink.cleanup"
-    schedule: every 4 hours
+    command: 'MagicLink.cleanup'
+    schedule: every 4 hours at minute 25

--- a/core/config/recurring.yml
+++ b/core/config/recurring.yml
@@ -12,8 +12,8 @@
 production:
   clear_solid_queue_finished_jobs:
     command: 'SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)'
-    schedule: every day at 00:10
+    schedule: every hour at minute 12
 
   cleanup_magic_links:
     command: 'MagicLink.cleanup'
-    schedule: every day at 00:20
+    schedule: every 4 hours


### PR DESCRIPTION
## Summary
- Added a new recurring job `cleanup_magic_links` in `core/config/recurring.yml` to prune stale magic links.
- Scheduled the cleanup job to run every 4 hours to maintain database health.

## Test plan
- [ ] Not run locally (verified `MagicLink.cleanup` logic in `app/models/magic_link.rb` and validated configuration syntax).