### PR TITLE
✨ [core]: Implement text length validation and refactor AI completion model

### DIFF
--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -6,14 +6,15 @@ class Api::V1::CompletionsController < Api::V1::BaseController
   before_action :check_rate_limit
 
   def create
-    result = Ai::Completion.perform(text: params[:text], prompt: params[:prompt])
+    result = @completion.perform
     render json: { result: result }, status: :ok
   end
 
   private
     def validate_params!
-      if params[:text].blank?
-        render json: { error: "Text parameter is required" }, status: :unprocessable_entity
+      @completion = Ai::Completion.new(text: params[:text], prompt: params[:prompt])
+      if @completion.invalid?
+        render json: { error: @completion.errors.full_messages.to_sentence }, status: :unprocessable_entity
       end
     end
 

--- a/core/app/models/ai/completion.rb
+++ b/core/app/models/ai/completion.rb
@@ -1,5 +1,9 @@
 module Ai
   class Completion
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
     DEFAULT_PROMPT = <<~PROMPT.freeze
       You are Typo's system assistant.
 
@@ -20,6 +24,12 @@ module Ai
       Text will be provided between ### markers.
     PROMPT
 
+    MAX_TEXT_LENGTH = 100
+
+    attr_accessor :text, :prompt
+
+    validates :text, presence: true, length: { maximum: MAX_TEXT_LENGTH }
+
     def self.perform(text:, prompt: nil)
       new(text: text, prompt: prompt).perform
     end
@@ -30,6 +40,8 @@ module Ai
     end
 
     def perform
+      return unless valid?
+
       chat = RubyLLM.chat
         .with_params(thinking: { type: "disabled" }, stream: false)
       # Note: I will test it later.

--- a/core/app/models/ai/completion.rb
+++ b/core/app/models/ai/completion.rb
@@ -2,7 +2,6 @@ module Ai
   class Completion
     include ActiveModel::Model
     include ActiveModel::Attributes
-    include ActiveModel::Validations
 
     DEFAULT_PROMPT = <<~PROMPT.freeze
       You are Typo's system assistant.
@@ -26,17 +25,14 @@ module Ai
 
     MAX_TEXT_LENGTH = 100
 
-    attr_accessor :text, :prompt
+    attribute :text, :string
+    attribute :prompt, :string, default: -> { DEFAULT_PROMPT }
 
     validates :text, presence: true, length: { maximum: MAX_TEXT_LENGTH }
 
-    def self.perform(text:, prompt: nil)
-      new(text: text, prompt: prompt).perform
-    end
-
-    def initialize(text:, prompt: nil)
-      @text = text
-      @prompt = prompt.presence || DEFAULT_PROMPT
+    def initialize(attributes = {})
+      super
+      self.prompt = prompt.presence || DEFAULT_PROMPT
     end
 
     def perform

--- a/core/app/models/ai/completion.rb
+++ b/core/app/models/ai/completion.rb
@@ -19,13 +19,14 @@ module Ai
       Input Format:
       Text will be provided between ### markers.
     PROMPT
-    def self.perform(text:, prompt: DEFAULT_PROMPT)
+
+    def self.perform(text:, prompt: nil)
       new(text: text, prompt: prompt).perform
     end
 
-    def initialize(text:, prompt: DEFAULT_PROMPT)
+    def initialize(text:, prompt: nil)
       @text = text
-      @prompt = prompt
+      @prompt = prompt.presence || DEFAULT_PROMPT
     end
 
     def perform

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -3,12 +3,12 @@ require "test_helper"
 class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     Rails.cache.clear
-    @original_perform = Ai::Completion.method(:perform)
-    Ai::Completion.define_singleton_method(:perform) { |**_| "__success__" }
+    @original_perform = Ai::Completion.instance_method(:perform)
+    Ai::Completion.define_method(:perform) { "__success__" }
   end
 
   teardown do
-    Ai::Completion.define_singleton_method(:perform, @original_perform)
+    Ai::Completion.define_method(:perform, @original_perform)
   end
 
   test "should get success on create" do
@@ -20,7 +20,14 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
   test "should return unprocessable_entity if text is missing" do
     post api_v1_completions_url, params: { prompt: "correct this" }, as: :json
     assert_response :unprocessable_entity
-    assert_equal "Text parameter is required", JSON.parse(response.body)["error"]
+    assert_equal "Text can't be blank", JSON.parse(response.body)["error"]
+  end
+
+  test "should return unprocessable_entity if text is too long" do
+    long_text = "a" * (Ai::Completion::MAX_TEXT_LENGTH + 1)
+    post api_v1_completions_url, params: { text: long_text }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal "Text is too long (maximum is #{Ai::Completion::MAX_TEXT_LENGTH} characters)", JSON.parse(response.body)["error"]
   end
 
   test "should rate limit after 5 requests" do

--- a/core/test/models/ai/completion_test.rb
+++ b/core/test/models/ai/completion_test.rb
@@ -10,7 +10,7 @@ class Ai::CompletionTest < ActiveSupport::TestCase
 
   test "Translate to English with default system prompt" do
     text = "你好，世界。"
-    result = Ai::Completion.perform(text: text)
+    result = Ai::Completion.new(text: text).perform
     assert_equal "Hello, world.", result
   end
 
@@ -19,7 +19,7 @@ class Ai::CompletionTest < ActiveSupport::TestCase
     prompt = <<~PROMPT.freeze
       Translate to Japanese
     PROMPT
-    result = Ai::Completion.perform(text: text, prompt: prompt)
+    result = Ai::Completion.new(text: text, prompt: prompt).perform
     assert_equal "こんにちは、世界。", result
   end
 
@@ -28,7 +28,7 @@ class Ai::CompletionTest < ActiveSupport::TestCase
     prompt = <<~PROMPT.freeze
       Translate to Chinese
     PROMPT
-    result = Ai::Completion.perform(text: text, prompt: prompt)
+    result = Ai::Completion.new(text: text, prompt: prompt).perform
     assert_equal "你好，世界。", result
   end
 end

--- a/scripts/core-curl-apis.sh
+++ b/scripts/core-curl-apis.sh
@@ -5,7 +5,7 @@ echo "🌍 Select environment:"
 ENV=$(gum choose "local" "production")
 
 if [ "$ENV" = "production" ]; then
-  BASE_URL="http://app.typo.yuler.cc/api/v1"
+  BASE_URL="https://app.typo.yuler.cc/api/v1"
 else
   BASE_URL="http://localhost:3000/api/v1"
 fi
@@ -13,22 +13,10 @@ fi
 api_v1_completions() {
   local URL="${BASE_URL}/completions"
 
-  echo "📝 Please enter the text to be processed (Ctrl+D to finish, default: __fake_test_text__):"
-  local TEXT=$(gum write --placeholder "Text to process...")
+  local TEXT=$(gum write --placeholder "Text to process..." --value "你好，世界" --header "📝 Please enter the text:")
+  local PROMPT=$(gum write --placeholder "e.g., Translate to English" --width 80 --header "🤖 Please enter the prompt (optional):" --value "Translate to English")
 
-  if [ -z "$TEXT" ]; then
-    TEXT="__fake_test_text__"
-  fi
-
-  echo "🤖 Please enter the prompt (optional, press Enter to use system default):"
-  local PROMPT=$(gum input --placeholder "e.g., Translate to Japanese" --width 80)
-
-  # Safely construct JSON payload using jq
-  if [ -n "$PROMPT" ]; then
-    local PAYLOAD=$(jq -n --arg text "$TEXT" --arg prompt "$PROMPT" '{text: $text, prompt: $prompt}')
-  else
-    local PAYLOAD=$(jq -n --arg text "$TEXT" '{text: $text}')
-  fi
+  local PAYLOAD=$(jq -n --arg text "$TEXT" --arg prompt "$PROMPT" '{text: $text, prompt: $prompt}')
 
   echo ""
   gum style --foreground 212 "Payload:"
@@ -47,7 +35,6 @@ api_v1_completions() {
   rm -f response.json
 }
 
-echo "Select an API to test:"
 ACTION=$(gum choose "api_v1_completions")
 
 case $ACTION in

--- a/scripts/core-curl-apis.sh
+++ b/scripts/core-curl-apis.sh
@@ -23,6 +23,11 @@ api_v1_completions() {
   echo "$PAYLOAD" | jq .
 
   echo ""
+  echo "curl command:"
+  echo "curl -X POST ${URL} \
+    -H 'Content-Type: application/json' \
+    -d '${PAYLOAD}'"
+  echo ""
   gum spin --spinner minidot --title "Sending request to $URL..." -- \
     curl -s -X POST "$URL" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- Refactored `Ai::Completion` to use `ActiveModel` for validation and attribute handling.
- Implemented a character limit (100) for the `text` parameter in AI completions to prevent excessive token usage.
- Updated `Api::V1::CompletionsController` to delegate input validation to the model.
- Fixed `Ai::Completion` test stubs to correctly mock instance methods.
- Improved `core-curl-apis.sh` script with HTTPS support, better interactive prompts, and `curl` command transparency.

## Test plan
- [x] Verified `scripts/core-curl-apis.sh` with `gum` and confirmed production `https` URL.
- [x] Added and passed unit test for text length limit in `CompletionsControllerTest`.
- [x] Verified model validation error messages (e.g., "Text can't be blank") are correctly returned by the API.