### PR TITLE
🐛 [core]: Fix device authorization redirect after onboarding

### DIFF
--- a/core/app/controllers/concerns/authentication.rb
+++ b/core/app/controllers/concerns/authentication.rb
@@ -78,8 +78,8 @@ module Authentication
       redirect_to_login_url
     end
 
-    def after_authentication_url(fallback_url = root_url)
-      session.delete(:return_to_after_authenticating) || fallback_url
+    def after_authentication_url(fallback: root_url)
+      session.delete(:return_to_after_authenticating) || fallback
     end
 
     def redirect_authenticated_user

--- a/core/app/controllers/concerns/authentication.rb
+++ b/core/app/controllers/concerns/authentication.rb
@@ -74,15 +74,12 @@ module Authentication
     end
 
     def request_authentication
-      if Current.account.present?
-        session[:return_to_after_authenticating] = request.url
-      end
-
+      session[:return_to_after_authenticating] = request.url
       redirect_to_login_url
     end
 
-    def after_authentication_url
-      session.delete(:return_to_after_authenticating) || root_url
+    def after_authentication_url(fallback_url = root_url)
+      session.delete(:return_to_after_authenticating) || fallback_url
     end
 
     def redirect_authenticated_user

--- a/core/app/controllers/onboardings_controller.rb
+++ b/core/app/controllers/onboardings_controller.rb
@@ -16,7 +16,7 @@ class OnboardingsController < ApplicationController
     @signup = Signup.new(signup_params.merge(identity: Current.identity))
 
     if @signup.create_personal_account
-      redirect_to root_url(script_name: "/#{@signup.account.slug}")
+      redirect_to after_authentication_url(fallback: root_url(script_name: "/#{@signup.account.slug}"))
     else
       render :new, status: :unprocessable_entity
     end
@@ -25,7 +25,7 @@ class OnboardingsController < ApplicationController
   private
     def redirect_if_onboarded
       if personal_account = Current.identity.personal_account
-        redirect_to root_url(script_name: "/#{personal_account.slug}")
+        redirect_to after_authentication_url(fallback: root_url(script_name: "/#{personal_account.slug}"))
       end
     end
 

--- a/core/test/integration/device_authorization_flow_test.rb
+++ b/core/test/integration/device_authorization_flow_test.rb
@@ -52,6 +52,41 @@ class DeviceAuthorizationFlowTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "device authorization flow for unauthenticated new user with onboarding redirect" do
+    post api_v1_device_authorization_url
+    assert_response :success
+    json = JSON.parse(response.body)
+    user_code = json["user_code"]
+
+    target_url = device_authorization_url(user_code: user_code)
+
+    # 1. Unauthenticated user attempts to visit authorization page directly
+    get target_url
+    assert_redirected_to new_session_url
+    follow_redirect!
+
+    # 2. New user submits email to sign up / login
+    new_email = "newbie@example.com"
+    post session_url, params: { email: new_email }
+    assert_redirected_to session_magic_link_url
+
+    identity = Identity.find_by!(email: new_email)
+    magic_link = identity.magic_links.last
+
+    # 3. User consumes magic link
+    post session_magic_link_url, params: { code: magic_link.code }
+    # Since new user has no accounts, they are redirected to onboarding
+    assert_redirected_to new_onboarding_url
+    follow_redirect!
+
+    # 4. User submits onboarding form
+    post onboarding_url, params: { signup: { username: "newbie", nickname: "Newbie" } }
+    # After onboarding, user should be redirected back to the device authorization page!
+    assert_redirected_to target_url
+    follow_redirect!
+    assert_response :success
+  end
+
   private
 
   def sign_in_as(identity)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "core:dev": "cd core && bin/dev",
     "core:test": "cd core && bin/rails test",
+    "core:test:controller": "cd core && bin/rails test:controllers",
     "core:lint": "cd core && bin/rubocop",
     "core:lint:fix": "cd core && bin/rubocop -A",
     "core:commands": "./scripts/core-commands.sh",

--- a/scripts/core-curl-apis.sh
+++ b/scripts/core-curl-apis.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+get_now_ms() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000'
+  else
+    date +%s%3N
+  fi
+}
+
 gum style --foreground 212 "🌍 Select environment:"
 ENV=$(gum choose "local" "production")
 
@@ -30,12 +38,12 @@ api_v1_completions() {
     -d '${PAYLOAD}'"
 
   printf "\n"
-  start_time=$(date +%s%3N)
+  start_time=$(get_now_ms)
   gum spin --spinner minidot --title "Sending request to $URL..." -- \
     curl -s -X POST "$URL" \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" > response.json
-  end_time=$(date +%s%3N)
+  end_time=$(get_now_ms)
   duration=$((end_time - start_time))
 
   printf "\n"
@@ -53,11 +61,11 @@ api_v1_device_authorization() {
   gum style --foreground 245 "curl -X POST ${URL} -H 'Content-Type: application/json'"
 
   printf "\n"
-  start_time=$(date +%s%3N)
+  start_time=$(get_now_ms)
   gum spin --spinner minidot --title "Sending request to $URL..." -- \
     curl -s -X POST "$URL" \
     -H "Content-Type: application/json" > response.json
-  end_time=$(date +%s%3N)
+  end_time=$(get_now_ms)
   duration=$((end_time - start_time))
 
   printf "\n"
@@ -85,12 +93,12 @@ api_v1_device_token() {
     -d '${PAYLOAD}'"
 
   printf "\n"
-  start_time=$(date +%s%3N)
+  start_time=$(get_now_ms)
   gum spin --spinner minidot --title "Sending request to $URL..." -- \
     curl -s -X POST "$URL" \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" > response.json
-  end_time=$(date +%s%3N)
+  end_time=$(get_now_ms)
   duration=$((end_time - start_time))
 
   printf "\n"
@@ -110,12 +118,12 @@ api_v1_test_private() {
   gum style --foreground 245 "curl -X GET ${URL} -H 'Content-Type: application/json' -H 'Authorization: Bearer ${TOKEN}'"
 
   printf "\n"
-  start_time=$(date +%s%3N)
+  start_time=$(get_now_ms)
   gum spin --spinner minidot --title "Sending request to $URL..." -- \
     curl -s -X GET "$URL" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${TOKEN}" > response.json
-  end_time=$(date +%s%3N)
+  end_time=$(get_now_ms)
   duration=$((end_time - start_time))
 
   printf "\n"

--- a/scripts/core-curl-apis.sh
+++ b/scripts/core-curl-apis.sh
@@ -3,11 +3,7 @@
 set -e
 
 get_now_ms() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000'
-  else
-    date +%s%3N
-  fi
+  perl -MTime::HiRes=time -e 'printf "%.0f\n", time * 1000'
 }
 
 gum style --foreground 212 "🌍 Select environment:"


### PR DESCRIPTION
## Summary
- Ensure `return_to_after_authenticating` session URL is stored unconditionally during authentication requests
- Support fallback redirect URL in `after_authentication_url` to correctly route new users back to the OAuth device authorization page after completing onboarding

## Test plan
- [x] Verified full device authorization flow integration test passes (`core/test/integration/device_authorization_flow_test.rb`)