### PR TITLE
✨ [core]: Add AI completion persistence and dashboard statistics

### DIFF
--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -6,23 +6,30 @@ class Api::V1::CompletionsController < Api::V1::BaseController
   before_action :check_rate_limit
 
   def create
-    result = @completion.perform
-
     if authenticated?
       account = Current.account || Current.identity.personal_account
-      if account
-        CompletionPersistenceJob.perform_later(
-          account_id: account.id,
-          user_id: Current.user&.id || Current.identity.users.find_by(account: account)&.id,
-          prompt: @completion.prompt,
-          input: @completion.text,
-          output: result.content,
-          model: result.model_id,
-          tokens: result.tokens,
-          duration_ms: result.duration_ms,
-          status: result.status
-        )
-      end
+      user = Current.user || Current.identity.users.find_by(account: account)
+    end
+
+    completion = Completion.create!(
+      account: account,
+      user: user,
+      prompt: @ai_completion.prompt,
+      input: @ai_completion.text,
+      status: "pending"
+    )
+
+    result = @ai_completion.perform
+
+    if result && result.status == "success"
+      CompletionPersistenceJob.perform_later(
+        completion,
+        output: result.content,
+        model: result.model_id,
+        tokens: result.tokens,
+        duration_ms: result.duration_ms,
+        status: result.status
+      )
     end
 
     render json: { result: result.content }, status: :ok
@@ -30,9 +37,9 @@ class Api::V1::CompletionsController < Api::V1::BaseController
 
   private
     def validate_params!
-      @completion = Ai::Completion.new(text: params[:text], prompt: params[:prompt])
-      if @completion.invalid?
-        render json: { error: @completion.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      @ai_completion = Ai::Completion.new(text: params[:text], prompt: params[:prompt])
+      if @ai_completion.invalid?
+        render json: { error: @ai_completion.errors.full_messages.to_sentence }, status: :unprocessable_entity
       end
     end
 

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -7,6 +7,24 @@ class Api::V1::CompletionsController < Api::V1::BaseController
 
   def create
     result = @completion.perform
+
+    if authenticated?
+      account = Current.account || Current.identity.personal_account
+      if account
+        Completion.create!(
+          account: account,
+          user: Current.user || Current.identity.users.find_by(account: account),
+          prompt: @completion.prompt,
+          input: params[:text],
+          output: result.content,
+          model: result.model_id,
+          tokens: result.tokens,
+          duration_ms: result.duration_ms,
+          status: result.status
+        )
+      end
+    end
+
     render json: { result: result.content }, status: :ok
   end
 

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
 
   def create
     result = @completion.perform
-    render json: { result: result }, status: :ok
+    render json: { result: result.content }, status: :ok
   end
 
   private

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
         completion,
         output: result.content,
         model: result.model_id,
-        tokens: result.tokens,
+        tokens: result.tokens&.to_h,
         duration_ms: result.duration_ms,
         status: result.status
       )

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -11,11 +11,11 @@ class Api::V1::CompletionsController < Api::V1::BaseController
     if authenticated?
       account = Current.account || Current.identity.personal_account
       if account
-        Completion.create!(
-          account: account,
-          user: Current.user || Current.identity.users.find_by(account: account),
+        CompletionPersistenceJob.perform_later(
+          account_id: account.id,
+          user_id: Current.user&.id || Current.identity.users.find_by(account: account)&.id,
           prompt: @completion.prompt,
-          input: params[:text],
+          input: @completion.text,
           output: result.content,
           model: result.model_id,
           tokens: result.tokens,

--- a/core/app/controllers/dashboards_controller.rb
+++ b/core/app/controllers/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class DashboardsController < ApplicationController
   def show
     @sessions = Current.identity.sessions.order(created_at: :desc)
+    @total_completions = Current.user.completions.count
   end
 end

--- a/core/app/jobs/completion_persistence_job.rb
+++ b/core/app/jobs/completion_persistence_job.rb
@@ -1,9 +1,9 @@
 class CompletionPersistenceJob < ApplicationJob
   queue_as :default
 
-  def perform(attributes)
-    Completion.create!(attributes)
-  rescue ActiveRecord::RecordInvalid => e
+  def perform(completion, attributes)
+    completion.update!(attributes)
+  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
     Rails.logger.error "Failed to persist completion: #{e.message}"
   end
 end

--- a/core/app/jobs/completion_persistence_job.rb
+++ b/core/app/jobs/completion_persistence_job.rb
@@ -1,0 +1,9 @@
+class CompletionPersistenceJob < ApplicationJob
+  queue_as :default
+
+  def perform(attributes)
+    Completion.create!(attributes)
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error "Failed to persist completion: #{e.message}"
+  end
+end

--- a/core/app/models/account.rb
+++ b/core/app/models/account.rb
@@ -1,6 +1,7 @@
 class Account < ApplicationRecord
   has_many :users
   has_many :identities, through: :users
+  has_many :completions, through: :users
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true, format: { with: AccountSlug::FORMAT },

--- a/core/app/models/ai/completion.rb
+++ b/core/app/models/ai/completion.rb
@@ -1,4 +1,6 @@
 module Ai
+  Result = Struct.new(:content, :tokens, :model_id, :duration_ms, :status)
+
   class Completion
     include ActiveModel::Model
     include ActiveModel::Attributes
@@ -38,15 +40,23 @@ module Ai
     def perform
       return unless valid?
 
+      start_time = Time.current
       chat = RubyLLM.chat
         .with_params(thinking: { type: "disabled" }, stream: false)
       # Note: I will test it later.
       # .with_params(  thinking: { type: "enabled" }, reasoning_effort: "high" )
       response = chat.with_instructions(prompt).ask("###\n#{text}\n###")
+      duration_ms = ((Time.current - start_time) * 1000).to_i
 
       Rails.logger.info({ model: chat.model.id, prompt: prompt, text: text, output: response.content, tokens: response.tokens, cost: response.cost&.total }.to_json)
 
-      response.content
+      Result.new(
+        response.content,
+        response.tokens,
+        chat.model.id,
+        duration_ms,
+        "success"
+      )
     end
   end
 end

--- a/core/app/models/completion.rb
+++ b/core/app/models/completion.rb
@@ -1,5 +1,5 @@
 class Completion < ApplicationRecord
-  belongs_to :account
+  belongs_to :account, optional: true
   belongs_to :user, optional: true
 
   validates :input, presence: true

--- a/core/app/models/completion.rb
+++ b/core/app/models/completion.rb
@@ -1,0 +1,7 @@
+class Completion < ApplicationRecord
+  belongs_to :account
+  belongs_to :user, optional: true
+
+  validates :input, presence: true
+  validates :status, presence: true
+end

--- a/core/app/models/user.rb
+++ b/core/app/models/user.rb
@@ -4,6 +4,15 @@ class User < ApplicationRecord
   belongs_to :account
   belongs_to :identity, optional: true
 
+  has_many :completions
+
   validates :name, presence: true
   validates :role, presence: true
+
+  delegate :email, to: :identity, allow_nil: true
+
+  def avatar_url(size: 80)
+    hash = identity&.email.present? ? Digest::MD5.hexdigest(identity.email.downcase.strip) : Digest::MD5.hexdigest(name.downcase.strip)
+    "https://secure.gravatar.com/avatar/#{hash}?s=#{size}&d=mp"
+  end
 end

--- a/core/app/views/dashboards/show.html.erb
+++ b/core/app/views/dashboards/show.html.erb
@@ -1,16 +1,22 @@
 <div class="flex justify-between items-center mb-8">
-  <h1 class="text-2xl font-bold"><%= t(".welcome_back", name: Current.user.name) %></h1>
+  <div class="flex items-center gap-3">
+    <%= image_tag Current.user.avatar_url(size: 40), class: "w-10 h-10 rounded-full border shadow-sm" %>
+    <div class="flex flex-col">
+      <h1 class="text-lg font-bold leading-tight"><%= Current.user.name %></h1>
+      <div class="text-xs text-muted"><%= Current.user.email %></div>
+    </div>
+  </div>
   <%= button_to t(".logout"), logout_url, method: :delete, class: "btn btn-secondary btn-sm" %>
 </div>
 
 <div class="grid grid-cols-2 gap-4 mb-8">
   <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".total_refinements") %></div>
-    <div class="text-3xl font-bold">0</div>
+    <div class="text-3xl font-bold"><%= @total_completions %></div>
   </div>
   <div class="p-6 border rounded-xl">
-    <div class="text-xs text-muted uppercase mb-2"><%= t(".active_prompts") %></div>
-    <div class="text-3xl font-bold">5</div>
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".slash_prompts") %></div>
+    <div class="text-sm font-medium text-muted flex items-center h-9"><%= t(".coming_soon") %></div>
   </div>
 </div>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -44,7 +44,8 @@ en:
       welcome_back: "Welcome back, %{name}"
       logout: "Logout"
       total_refinements: "Total Refinements"
-      active_prompts: "Active Prompts"
+      slash_prompts: "Slash prompts"
+      coming_soon: "Coming soon"
       my_sessions: "My Sessions"
       manage_sessions: "Manage sessions"
   onboardings:

--- a/core/db/migrate/20260518000000_create_completions.rb
+++ b/core/db/migrate/20260518000000_create_completions.rb
@@ -1,7 +1,7 @@
 class CreateCompletions < ActiveRecord::Migration[8.2]
   def change
     create_table :completions, id: :uuid do |t|
-      t.references :account, type: :uuid, null: false, index: true
+      t.references :account, type: :uuid, null: true, index: true
       t.references :user, type: :uuid, null: true, index: true
       t.text :prompt
       t.text :input

--- a/core/db/migrate/20260518000000_create_completions.rb
+++ b/core/db/migrate/20260518000000_create_completions.rb
@@ -1,0 +1,17 @@
+class CreateCompletions < ActiveRecord::Migration[8.2]
+  def change
+    create_table :completions, id: :uuid do |t|
+      t.references :account, type: :uuid, null: false, index: true
+      t.references :user, type: :uuid, null: true, index: true
+      t.text :prompt
+      t.text :input
+      t.text :output
+      t.string :model
+      t.json :tokens
+      t.integer :duration_ms
+      t.string :status, default: "success", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/core/db/schema.rb
+++ b/core/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_15_000002) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_18_000000) do
   create_table "accounts", id: :uuid, force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
@@ -19,6 +19,22 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_15_000002) do
     t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_accounts_on_slug", unique: true
+  end
+
+  create_table "completions", id: :uuid, force: :cascade do |t|
+    t.uuid "account_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "duration_ms"
+    t.text "input"
+    t.string "model"
+    t.text "output"
+    t.text "prompt"
+    t.string "status", default: "success", null: false
+    t.json "tokens"
+    t.datetime "updated_at", null: false
+    t.uuid "user_id"
+    t.index ["account_id"], name: "index_completions_on_account_id"
+    t.index ["user_id"], name: "index_completions_on_user_id"
   end
 
   create_table "device_authorizations", id: :uuid, force: :cascade do |t|

--- a/core/db/schema.rb
+++ b/core/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_18_000000) do
   end
 
   create_table "completions", id: :uuid, force: :cascade do |t|
-    t.uuid "account_id", null: false
+    t.uuid "account_id"
     t.datetime "created_at", null: false
     t.integer "duration_ms"
     t.text "input"

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     Rails.cache.clear
     @original_perform = Ai::Completion.instance_method(:perform)
@@ -59,13 +61,15 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     identity.users.create!(account: account, role: :owner, name: "Test User")
     token = identity.signed_id(purpose: :api_token)
 
-    assert_difference "Completion.count", 1 do
+    assert_enqueued_with(job: CompletionPersistenceJob) do
       post api_v1_completions_url,
            params: { text: "persist me" },
            headers: { "Authorization" => "Bearer #{token}" },
            as: :json
     end
     assert_response :success
+
+    perform_enqueued_jobs
 
     completion = Completion.last
     assert_equal account, completion.account

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -52,4 +52,24 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
   end
+
+  test "creates a Completion record for authenticated users" do
+    account = Account.create!(name: "Personal", personal: true)
+    identity = Identity.create!(email: "test@example.com")
+    identity.users.create!(account: account, role: :owner, name: "Test User")
+    token = identity.signed_id(purpose: :api_token)
+
+    assert_difference "Completion.count", 1 do
+      post api_v1_completions_url,
+           params: { text: "persist me" },
+           headers: { "Authorization" => "Bearer #{token}" },
+           as: :json
+    end
+    assert_response :success
+
+    completion = Completion.last
+    assert_equal account, completion.account
+    assert_equal "persist me", completion.input
+    assert_equal "__success__", completion.output
+  end
 end

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -4,7 +4,9 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
   setup do
     Rails.cache.clear
     @original_perform = Ai::Completion.instance_method(:perform)
-    Ai::Completion.define_method(:perform) { "__success__" }
+    Ai::Completion.define_method(:perform) do
+      Ai::Result.new("__success__", { "total" => 10 }, "test-model", 100, "success")
+    end
   end
 
   teardown do

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -69,11 +69,36 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
 
-    perform_enqueued_jobs
-
     completion = Completion.last
     assert_equal account, completion.account
     assert_equal "persist me", completion.input
+    assert_equal "pending", completion.status
+
+    perform_enqueued_jobs
+
+    completion.reload
     assert_equal "__success__", completion.output
+    assert_equal "success", completion.status
+  end
+
+  test "creates a Completion record for anonymous users" do
+    assert_enqueued_with(job: CompletionPersistenceJob) do
+      post api_v1_completions_url,
+           params: { text: "anonymous text" },
+           as: :json
+    end
+    assert_response :success
+
+    completion = Completion.last
+    assert_nil completion.account
+    assert_nil completion.user
+    assert_equal "anonymous text", completion.input
+    assert_equal "pending", completion.status
+
+    perform_enqueued_jobs
+
+    completion.reload
+    assert_equal "__success__", completion.output
+    assert_equal "success", completion.status
   end
 end

--- a/core/test/jobs/completion_persistence_job_test.rb
+++ b/core/test/jobs/completion_persistence_job_test.rb
@@ -1,30 +1,29 @@
 require "test_helper"
 
 class CompletionPersistenceJobTest < ActiveJob::TestCase
-  test "creates a completion record" do
+  test "updates a completion record" do
     account = Account.create!(name: "Test Account")
+    completion = Completion.create!(account: account, input: "hello", status: "pending")
     attributes = {
-      account_id: account.id,
-      input: "hello",
       output: "hi",
       status: "success"
     }
 
-    assert_difference "Completion.count", 1 do
-      CompletionPersistenceJob.perform_now(attributes)
+    assert_no_difference "Completion.count" do
+      CompletionPersistenceJob.perform_now(completion, attributes)
     end
 
-    completion = Completion.last
-    assert_equal "hello", completion.input
-    assert_equal "hi", completion.output
+    assert_equal "hi", completion.reload.output
+    assert_equal "success", completion.status
   end
 
   test "logs error on invalid attributes" do
-    attributes = { input: nil }
+    completion = Completion.create!(input: "hello", status: "pending")
+    attributes = { status: nil }
 
     assert_no_difference "Completion.count" do
       # Should not raise error but log it
-      CompletionPersistenceJob.perform_now(attributes)
+      CompletionPersistenceJob.perform_now(completion, attributes)
     end
   end
 end

--- a/core/test/jobs/completion_persistence_job_test.rb
+++ b/core/test/jobs/completion_persistence_job_test.rb
@@ -21,7 +21,7 @@ class CompletionPersistenceJobTest < ActiveJob::TestCase
 
   test "logs error on invalid attributes" do
     attributes = { input: nil }
-    
+
     assert_no_difference "Completion.count" do
       # Should not raise error but log it
       CompletionPersistenceJob.perform_now(attributes)

--- a/core/test/jobs/completion_persistence_job_test.rb
+++ b/core/test/jobs/completion_persistence_job_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class CompletionPersistenceJobTest < ActiveJob::TestCase
+  test "creates a completion record" do
+    account = Account.create!(name: "Test Account")
+    attributes = {
+      account_id: account.id,
+      input: "hello",
+      output: "hi",
+      status: "success"
+    }
+
+    assert_difference "Completion.count", 1 do
+      CompletionPersistenceJob.perform_now(attributes)
+    end
+
+    completion = Completion.last
+    assert_equal "hello", completion.input
+    assert_equal "hi", completion.output
+  end
+
+  test "logs error on invalid attributes" do
+    attributes = { input: nil }
+    
+    assert_no_difference "Completion.count" do
+      # Should not raise error but log it
+      CompletionPersistenceJob.perform_now(attributes)
+    end
+  end
+end

--- a/core/test/models/ai/completion_test.rb
+++ b/core/test/models/ai/completion_test.rb
@@ -11,7 +11,10 @@ class Ai::CompletionTest < ActiveSupport::TestCase
   test "Translate to English with default system prompt" do
     text = "你好，世界。"
     result = Ai::Completion.new(text: text).perform
-    assert_equal "Hello, world.", result
+    assert_equal "Hello, world.", result.content
+    assert_respond_to result, :tokens
+    assert_respond_to result, :model_id
+    assert_respond_to result, :duration_ms
   end
 
   test "Translate to Japanese" do
@@ -20,7 +23,7 @@ class Ai::CompletionTest < ActiveSupport::TestCase
       Translate to Japanese
     PROMPT
     result = Ai::Completion.new(text: text, prompt: prompt).perform
-    assert_equal "こんにちは、世界。", result
+    assert_equal "こんにちは、世界。", result.content
   end
 
   test "Translate to Chinese" do
@@ -29,6 +32,6 @@ class Ai::CompletionTest < ActiveSupport::TestCase
       Translate to Chinese
     PROMPT
     result = Ai::Completion.new(text: text, prompt: prompt).perform
-    assert_equal "你好，世界。", result
+    assert_equal "你好，世界。", result.content
   end
 end

--- a/core/test/models/completion_test.rb
+++ b/core/test/models/completion_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class CompletionTest < ActiveSupport::TestCase
+  test "should be valid with required attributes" do
+    account = Account.create!(name: "Test Account")
+    completion = Completion.new(
+      account: account,
+      input: "hello",
+      output: "hi",
+      prompt: "be helpful",
+      model: "test-model",
+      tokens: { total: 10 },
+      duration_ms: 100,
+      status: "success"
+    )
+    assert completion.valid?
+  end
+
+  test "should be invalid without input" do
+    account = Account.create!(name: "Test Account")
+    completion = Completion.new(
+      account: account,
+      status: "success"
+    )
+    assert_not completion.valid?
+    assert_includes completion.errors[:input], "can't be blank"
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Completion` ActiveRecord model and asynchronous background job (`CompletionPersistenceJob`) to persist AI completion history
- Support anonymous (unauthenticated) completions by tracking records with pending status before third-party API execution
- Update `Api::V1::CompletionsController` and `Ai::Completion` to return structured results including token usage and execution duration
- Enhance user dashboard header with Gravatar avatar, email display, and real-time total completion counts

## Test plan
- [x] Ran unit and integration tests across `Completion`, `Ai::Completion`, controller, and background jobs (39 tests passing)