### PR TITLE
✨ [desktop,core] Add desktop custom User-Agent, server logout, and real-time sessions

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -38,13 +38,20 @@ fn request_mac_accessibility_permissions() -> Result<bool, String> {
 #[derive(Serialize)]
 struct SystemInfo {
     os: String,
+    version: String,
     is_wayland: bool,
 }
 
 #[tauri::command]
-fn get_system_info() -> SystemInfo {
+fn get_system_info(app: tauri::AppHandle) -> SystemInfo {
     SystemInfo {
-        os: std::env::consts::OS.to_string(),
+        os: match std::env::consts::OS {
+            "macos" => "macOS".to_string(),
+            "windows" => "Windows".to_string(),
+            "linux" => "Linux".to_string(),
+            _ => std::env::consts::OS.to_string(),
+        },
+        version: app.package_info().version.to_string(),
         is_wayland: in_linux_wayland(),
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -45,12 +45,7 @@ struct SystemInfo {
 #[tauri::command]
 fn get_system_info(app: tauri::AppHandle) -> SystemInfo {
     SystemInfo {
-        os: match std::env::consts::OS {
-            "macos" => "macOS".to_string(),
-            "windows" => "Windows".to_string(),
-            "linux" => "Linux".to_string(),
-            _ => std::env::consts::OS.to_string(),
-        },
+        os: std::env::consts::OS.to_string(),
         version: app.package_info().version.to_string(),
         is_wayland: in_linux_wayland(),
     }

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -45,5 +45,9 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
     throw new Error(error.error || `HTTP error! status: ${response.status}`)
   }
 
+  if (response.status === 204) {
+    return null as T
+  }
+
   return response.json()
 }

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -6,21 +6,30 @@ export const API_BASE_URL = 'https://app.typo.yuler.cc'
 // TODO: Add switchable local and production api
 // export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? 'http://localhost:3000' : 'https://app.typo.yuler.cc')
 
-let cachedUserAgent: string | null = null
+let userAgentPromise: Promise<string> | null = null
 
-async function getUserAgent(): Promise<string> {
-  if (cachedUserAgent)
-    return cachedUserAgent
+function getUserAgent(): Promise<string> {
+  if (userAgentPromise)
+    return userAgentPromise
 
-  try {
-    const { os, version } = await invoke<{ os: string, version: string }>('get_system_info')
-    cachedUserAgent = `Typo (${os}; version ${version})`
-  }
-  catch (error) {
-    console.error('failed to get system info for user agent', error)
-    cachedUserAgent = 'Typo (Unknown; version Unknown)'
-  }
-  return cachedUserAgent
+  userAgentPromise = (async () => {
+    try {
+      const { os, version } = await invoke<{ os: string, version: string }>('get_system_info')
+      const platformMap: Record<string, string> = {
+        macos: 'macOS',
+        windows: 'Windows',
+        linux: 'Linux',
+      }
+      const platform = platformMap[os] || os
+      return `Typo (${platform}; version ${version})`
+    }
+    catch (error) {
+      console.error('failed to get system info for user agent', error)
+      return 'Typo (Unknown; version Unknown)'
+    }
+  })()
+
+  return userAgentPromise
 }
 
 export async function api<T>(path: string, options?: RequestInit): Promise<T> {

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core'
 import { fetch } from '@tauri-apps/plugin-http'
 
 export const API_BASE_URL = 'https://app.typo.yuler.cc'
@@ -5,11 +6,31 @@ export const API_BASE_URL = 'https://app.typo.yuler.cc'
 // TODO: Add switchable local and production api
 // export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? 'http://localhost:3000' : 'https://app.typo.yuler.cc')
 
+let cachedUserAgent: string | null = null
+
+async function getUserAgent(): Promise<string> {
+  if (cachedUserAgent)
+    return cachedUserAgent
+
+  try {
+    const { os, version } = await invoke<{ os: string, version: string }>('get_system_info')
+    cachedUserAgent = `Typo (${os}; version ${version})`
+  }
+  catch (error) {
+    console.error('failed to get system info for user agent', error)
+    cachedUserAgent = 'Typo (Unknown; version Unknown)'
+  }
+  return cachedUserAgent
+}
+
 export async function api<T>(path: string, options?: RequestInit): Promise<T> {
+  const userAgent = await getUserAgent()
+
   const response = await fetch(`${API_BASE_URL}${path}`, {
     ...options,
     headers: {
       'Content-Type': 'application/json',
+      'User-Agent': userAgent,
       ...options?.headers,
     },
   })

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -20,11 +20,11 @@ function getUserAgent(): Promise<string> {
         windows: 'Windows',
         linux: 'Linux',
       }[os] || os
-      return `Typo (${platform}; version ${version})`
+      return `Typo Desktop/${version} (${platform})`
     }
     catch (error) {
       console.error('failed to get system info for user agent', error)
-      return 'Typo (Unknown; version Unknown)'
+      return 'Typo Desktop/Unknown (Unknown)'
     }
   })()
 

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -1,10 +1,7 @@
 import { invoke } from '@tauri-apps/api/core'
 import { fetch } from '@tauri-apps/plugin-http'
 
-export const API_BASE_URL = 'https://app.typo.yuler.cc'
-
-// TODO: Add switchable local and production api
-// export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || (import.meta.env.DEV ? 'http://localhost:3000' : 'https://app.typo.yuler.cc')
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://app.typo.yuler.cc'
 
 let userAgentPromise: Promise<string> | null = null
 

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -15,12 +15,11 @@ function getUserAgent(): Promise<string> {
   userAgentPromise = (async () => {
     try {
       const { os, version } = await invoke<{ os: string, version: string }>('get_system_info')
-      const platformMap: Record<string, string> = {
+      const platform = {
         macos: 'macOS',
         windows: 'Windows',
         linux: 'Linux',
-      }
-      const platform = platformMap[os] || os
+      }[os] || os
       return `Typo (${platform}; version ${version})`
     }
     catch (error) {

--- a/apps/desktop/src/components/BasicSettings.vue
+++ b/apps/desktop/src/components/BasicSettings.vue
@@ -191,7 +191,7 @@ onMounted(async () => {
   form.value.copy_result = copyResult
   form.value.global_shortcut = globalShortcut || DEFAULT_GLOBAL_SHORTCUT
 
-  const systemInfo = await invoke<{ os: string, is_wayland: boolean }>('get_system_info')
+  const systemInfo = await invoke<{ os: string, version: string, is_wayland: boolean }>('get_system_info')
   if (!isMounted)
     return
   isMacOS.value = systemInfo.os === 'macos'

--- a/apps/desktop/src/composables/useAuth.ts
+++ b/apps/desktop/src/composables/useAuth.ts
@@ -124,7 +124,20 @@ export const useAuth = createGlobalState(() => {
 
   async function logout() {
     cancel()
-    // TODO: Invoke API to remove current session on server once endpoint is available
+    const token = await authStore.getAuth('access_token')
+    if (token) {
+      try {
+        await api('/api/v1/session', {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+      }
+      catch (err) {
+        logger.error('Auth', 'Failed to remove session on server', err)
+      }
+    }
     isLoggedIn.value = false
     user.value = {
       name: '',

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -149,7 +149,7 @@ async function processSetInputPayload(payload: SetInputPayload) {
 }
 
 onMounted(async () => {
-  const systemInfo = await invoke<{ os: string, is_wayland: boolean }>('get_system_info')
+  const systemInfo = await invoke<{ os: string, version: string, is_wayland: boolean }>('get_system_info')
   if (!isMounted) {
     return
   }

--- a/apps/desktop/src/windows/Main.vue
+++ b/apps/desktop/src/windows/Main.vue
@@ -78,7 +78,7 @@ onMounted(async () => {
     return
   }
 
-  const systemInfo = await invoke<{ os: string, is_wayland: boolean }>('get_system_info')
+  const systemInfo = await invoke<{ os: string, version: string, is_wayland: boolean }>('get_system_info')
   if (!isMounted) {
     return
   }

--- a/core/app/models/session.rb
+++ b/core/app/models/session.rb
@@ -3,6 +3,8 @@ class Session < ApplicationRecord
 
   enum :kind, { web: "web", desktop: "desktop" }
 
+  broadcasts_to ->(session) { [ session.identity, "sessions" ] }, inserts_by: :prepend, target: "sessions", partial: "my/sessions/session"
+
   def user_agent_summary
     return "Unknown Device" if user_agent.blank?
 

--- a/core/app/models/session.rb
+++ b/core/app/models/session.rb
@@ -1,11 +1,13 @@
 class Session < ApplicationRecord
   belongs_to :identity
 
+  enum :kind, { web: "web", desktop: "desktop" }
+
   def user_agent_summary
     return "Unknown Device" if user_agent.blank?
 
     os = case user_agent
-    when /Macintosh|Mac OS X/i then "macOS"
+    when /Macintosh|Mac OS X|macOS/i then "macOS"
     when /Windows/i then "Windows"
     when /Linux/i then "Linux"
     when /iPhone/i then "iPhone"
@@ -28,5 +30,12 @@ class Session < ApplicationRecord
     else
       user_agent.truncate(35)
     end
+  end
+
+  def desktop_version
+    return unless desktop? && user_agent.present?
+
+    match = user_agent[%r{Typo Desktop/([^\s]+)}, 1]
+    "v#{match}" if match.present?
   end
 end

--- a/core/app/views/dashboards/show.html.erb
+++ b/core/app/views/dashboards/show.html.erb
@@ -19,6 +19,7 @@
     <h2 class="text-xl font-bold"><%= t(".my_sessions") %></h2>
     <%= link_to t(".manage_sessions"), my_sessions_path, class: "text-sm text-muted" %>
   </div>
+  <%= turbo_stream_from Current.identity, "sessions" %>
   <%= turbo_frame_tag "sessions", class: "flex flex-col gap-4" do %>
     <%= render partial: "my/sessions/session", collection: @sessions %>
   <% end %>

--- a/core/app/views/layouts/application.html.erb
+++ b/core/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= action_cable_meta_tag %>
 
     <%= yield :head %>
 

--- a/core/app/views/my/sessions/_session.html.erb
+++ b/core/app/views/my/sessions/_session.html.erb
@@ -3,7 +3,12 @@
     <span class="absolute top-2 right-2 bg-zinc-900 text-white px-2 py-0.5 rounded-full text-xs font-medium"><%= t(".current") %></span>
   <% end %>
   <div class="flex flex-col gap-1 <%= 'pt-2' if session == Current.session %>">
-    <div class="font-bold text-base" title="<%= session.user_agent %>"><%= session.user_agent_summary %></div>
+    <div class="font-bold text-base flex items-center gap-2" title="<%= session.user_agent %>">
+      <%= session.user_agent_summary %>
+      <% if session.desktop? && session.desktop_version.present? %>
+        <span class="bg-zinc-100 px-2 py-0.5 rounded-md text-xs font-mono font-normal"><%= session.desktop_version %></span>
+      <% end %>
+    </div>
     <div class="text-sm text-muted mt-1">
       <span class="bg-zinc-100 px-2 py-0.5 rounded-md text-xs font-mono uppercase"><%= session.kind %></span>
       <%= t(".ip", ip: session.ip_address) %> • <%= t(".time_ago", time: time_ago_in_words(session.created_at)) %>

--- a/core/app/views/my/sessions/index.html.erb
+++ b/core/app/views/my/sessions/index.html.erb
@@ -2,6 +2,7 @@
   <h1 class="text-2xl font-bold"><%= t(".title") %></h1>
 </div>
 
+<%= turbo_stream_from Current.identity, "sessions" %>
 <%= turbo_frame_tag "sessions", class: "flex flex-col gap-4" do %>
   <%= render partial: "my/sessions/session", collection: @sessions %>
 <% end %>

--- a/core/config/cable.yml
+++ b/core/config/cable.yml
@@ -3,7 +3,12 @@
 # not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
 # to make the web console appear.
 development:
-  adapter: async
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
 
 test:
   adapter: test

--- a/core/config/database.yml
+++ b/core/config/database.yml
@@ -10,8 +10,13 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  cable:
+    <<: *default
+    database: storage/development_cable.sqlite3
+    migrations_paths: db/cable_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/core/config/environments/development.rb
+++ b/core/config/environments/development.rb
@@ -65,7 +65,7 @@ Rails.application.configure do
   config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true

--- a/core/config/initializers/account_slug.rb
+++ b/core/config/initializers/account_slug.rb
@@ -3,7 +3,7 @@ module AccountSlug
   FORMAT = /\A[a-z0-9\-_]+\z/
   LENGTH = 4..16
   PATH_INFO_MATCH = /\A(\/#{AccountSlug::PATTERN})/
-  RESERVED_SLUGS = %w[session dashboard onboarding dev admin api assets billing help jobs login logout magic_link rails settings setup static support typo device]
+  RESERVED_SLUGS = %w[session dashboard onboarding dev admin api assets billing help jobs login logout magic_link rails settings setup static support typo device cable]
 
   class Extractor
     def initialize(app)

--- a/core/test/models/session_test.rb
+++ b/core/test/models/session_test.rb
@@ -13,6 +13,6 @@ class SessionTest < ActiveSupport::TestCase
 
   test "desktop_version returns nil for web sessions" do
     session = Session.new(kind: :web, user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")
-    assert_nil session.version
+    assert_nil session.desktop_version
   end
 end

--- a/core/test/models/session_test.rb
+++ b/core/test/models/session_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class SessionTest < ActiveSupport::TestCase
+  test "user_agent_summary correctly identifies macOS desktop app" do
+    session = Session.new(user_agent: "Typo Desktop/0.1.0 (macOS)")
+    assert_equal "Typo Client on macOS", session.user_agent_summary
+  end
+
+  test "desktop_version returns correct desktop version tag" do
+    session = Session.new(kind: :desktop, user_agent: "Typo Desktop/0.1.0 (macOS)")
+    assert_equal "v0.1.0", session.desktop_version
+  end
+
+  test "desktop_version returns nil for web sessions" do
+    session = Session.new(kind: :web, user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")
+    assert_nil session.version
+  end
+end

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "core:dev": "cd core && bin/dev",
+    "core:setup": "cd core && bin/setup",
     "core:test": "cd core && bin/rails test",
     "core:test:controller": "cd core && bin/rails test:controllers",
     "core:lint": "cd core && bin/rubocop",


### PR DESCRIPTION
## Summary
- Construct and inject a custom `User-Agent` header (`Typo Desktop/<version> (<platform>)`) into Core API requests from the desktop app
- Enhance Tauri `get_system_info` command to provide app version and descriptive OS names
- Add session kind (`web` vs `desktop`) and version tracking to the core Rails backend, displaying version badges in the sessions UI
- Implement real-time session broadcasting via `solid_cable` and Turbo Streams to dynamically update active sessions in the dashboard
- Handle HTTP 204 No Content API responses and invoke `DELETE /api/v1/session` on desktop logout to remove server-side sessions
- Allow configuring desktop API base URL via `VITE_API_BASE_URL` environment variable

## Test plan
- [x] Verified Rust compilation with `cargo check`
- [x] Verified frontend build for desktop client
- [x] Ran Rails unit tests in `core/test/models/session_test.rb`