### PR TITLE
feat: add cross-platform dock/taskbar icon visibility toggle

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -223,6 +223,18 @@ pub fn run() {
             if startup_selection && in_linux_wayland() {
                 app_cli_startup_selection_trigger(&app.handle());
             }
+
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                use tauri_plugin_store::StoreExt;
+                if let Some(store) = handle.get_store("settings.json") {
+                    let show_dock_icon = store.get("show_dock_icon")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(cfg!(not(target_os = "macos")));
+                    let _ = windows::set_dock_icon_visible(handle, show_dock_icon);
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -239,10 +251,11 @@ pub fn run() {
             keyboard::keyboard_select_all,
             keyboard::keyboard_paste_text,
             consume_pending_selection_input,
-            tray::update_tray_menu,
+            windows::update_tray_menu,
             windows::open_upgrade_window,
             windows::open_indicator_window,
-        ])
+            windows::set_dock_icon_visible,
+            ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -251,11 +251,10 @@ pub fn run() {
             keyboard::keyboard_select_all,
             keyboard::keyboard_paste_text,
             consume_pending_selection_input,
-            windows::update_tray_menu,
+            tray::update_tray_menu,
             windows::open_upgrade_window,
             windows::open_indicator_window,
             windows::set_dock_icon_visible,
-            ])
-        .run(tauri::generate_context!())
+            ])        .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -212,28 +212,40 @@ pub fn run() {
         }))
         .setup(move |app| {
             log::info!("in_linux_wayland={}", in_linux_wayland());
+
+            use tauri_plugin_store::StoreExt;
+            let show_dock_icon = if let Ok(store) = app.store("settings.json") {
+                store.get("show_dock_icon")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(cfg!(not(target_os = "macos")))
+            } else {
+                cfg!(not(target_os = "macos"))
+            };
+
+            #[cfg(target_os = "macos")]
+            {
+                let policy = if show_dock_icon {
+                    tauri::ActivationPolicy::Regular
+                } else {
+                    tauri::ActivationPolicy::Accessory
+                };
+                app.set_activation_policy(policy);
+            }
+
             windows::create_main_window(&app.handle());
             windows::create_indicator_window(&app.handle(), false);
             if let Err(error) = tray::init(app) {
                 log::error!("failed to initialize system tray: {}", error);
             }
-            #[cfg(target_os = "macos")]
-            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = windows::set_dock_icon_visible(app.handle().clone(), show_dock_icon);
+            }
 
             if startup_selection && in_linux_wayland() {
                 app_cli_startup_selection_trigger(&app.handle());
             }
-
-            let handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                use tauri_plugin_store::StoreExt;
-                if let Some(store) = handle.get_store("settings.json") {
-                    let show_dock_icon = store.get("show_dock_icon")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(cfg!(not(target_os = "macos")));
-                    let _ = windows::set_dock_icon_visible(handle, show_dock_icon);
-                }
-            });
 
             Ok(())
         })

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -30,8 +30,10 @@ pub fn set_dock_icon_visible(app: tauri::AppHandle, visible: bool) -> Result<(),
 
     #[cfg(not(target_os = "macos"))]
     {
-        if let Some(window) = app.get_webview_window("main") {
-            window.set_skip_taskbar(!visible).map_err(|e| e.to_string())?;
+        for window in app.webview_windows().values() {
+            if window.label() != "indicator" {
+                window.set_skip_taskbar(!visible).map_err(|e| e.to_string())?;
+            }
         }
     }
     Ok(())

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -15,6 +15,28 @@ pub fn open_indicator_window(app: AppHandle) {
     create_indicator_window(&app, true);
 }
 
+#[tauri::command]
+pub fn set_dock_icon_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use tauri::ActivationPolicy;
+        let policy = if visible {
+            ActivationPolicy::Regular
+        } else {
+            ActivationPolicy::Accessory
+        };
+        app.set_activation_policy(policy).map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(window) = app.get_webview_window("main") {
+            window.set_skip_taskbar(!visible).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
 pub fn create_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.set_focus();

--- a/apps/desktop/src/components/BasicSettings.vue
+++ b/apps/desktop/src/components/BasicSettings.vue
@@ -32,6 +32,7 @@ const form = ref({
   autostart: false,
   autoselect: false,
   copy_result: false,
+  show_dock_icon: true,
   global_shortcut: '',
 })
 
@@ -184,16 +185,18 @@ onMounted(async () => {
     return
   form.value.autostart = autostartEnabled
 
-  const [autoselect, copyResult, globalShortcut] = await Promise.all([
+  const [autoselect, copyResult, globalShortcut, showDockIcon] = await Promise.all([
     store.get('autoselect'),
     store.get('copy_result'),
     store.get('global_shortcut'),
+    store.get('show_dock_icon'),
   ])
   if (!isMounted)
     return
   form.value.autoselect = autoselect
   form.value.copy_result = copyResult
   form.value.global_shortcut = globalShortcut || DEFAULT_GLOBAL_SHORTCUT
+  form.value.show_dock_icon = showDockIcon
 
   const systemInfo = await invoke<{ os: string, version: string, is_wayland: boolean }>('get_system_info')
   if (!isMounted)
@@ -229,6 +232,19 @@ async function onAutostartToggle(value: boolean) {
   catch (error) {
     logger.error('BasicSettings', 'Failed to update autostart setting:', error)
     form.value.autostart = !value
+  }
+}
+
+async function onShowDockIconToggle(value: boolean) {
+  form.value.show_dock_icon = value
+  try {
+    await invoke('set_dock_icon_visible', { visible: value })
+    await store.set('show_dock_icon', value)
+    await store.save()
+  }
+  catch (error) {
+    logger.error('BasicSettings', 'Failed to update dock icon visibility setting:', error)
+    form.value.show_dock_icon = !value
   }
 }
 
@@ -314,6 +330,16 @@ async function onSubmit() {
                   </p>
                 </div>
                 <Switch id="autostart" :model-value="form.autostart" @update:model-value="onAutostartToggle" />
+              </div>
+
+              <div class="flex items-center justify-between">
+                <div class="space-y-0.5">
+                  <Label class="text-base font-semibold">{{ t('settings.basic.show_dock_icon.label') }}</Label>
+                  <p class="text-sm text-muted-foreground">
+                    {{ t('settings.basic.show_dock_icon.description') }}
+                  </p>
+                </div>
+                <Switch id="show_dock_icon" :model-value="form.show_dock_icon" @update:model-value="onShowDockIconToggle" />
               </div>
 
               <div class="flex items-center justify-between">

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -12,6 +12,8 @@
   "settings.basic.copy_result.description": "Automatically copy the polished result to your clipboard.",
   "settings.basic.autostart.label": "Launch at login",
   "settings.basic.autostart.description": "Automatically start the app when you log in.",
+  "settings.basic.show_dock_icon.label": "Show icon in Dock / Taskbar",
+  "settings.basic.show_dock_icon.description": "Display the application icon in the system taskbar or dock.",
   "settings.basic.shortcut.label": "Global Shortcut",
   "settings.basic.shortcut.listening": "Listening...",
   "settings.basic.shortcut.reset": "Reset",

--- a/apps/desktop/src/locales/jp.json
+++ b/apps/desktop/src/locales/jp.json
@@ -12,6 +12,8 @@
   "settings.basic.copy_result.description": "校正完了後、結果を自動的にクリップボードにコピーします。",
   "settings.basic.autostart.label": "ログイン時に起動",
   "settings.basic.autostart.description": "ログイン時にアプリを自動的に起動します。",
+  "settings.basic.show_dock_icon.label": "Dock / タスクバーにアイコンを表示",
+  "settings.basic.show_dock_icon.description": "システムタスクバーまたは Dock にアプリケーションアイコンを表示します。",
   "settings.basic.shortcut.label": "グローバルショートカット",
   "settings.basic.shortcut.listening": "入力待ち...",
   "settings.basic.shortcut.reset": "リセット",

--- a/apps/desktop/src/locales/zh.json
+++ b/apps/desktop/src/locales/zh.json
@@ -12,6 +12,8 @@
   "settings.basic.copy_result.description": "润色完成后，自动将结果复制到剪贴板。",
   "settings.basic.autostart.label": "开机自启动",
   "settings.basic.autostart.description": "登录系统时自动启动应用。",
+  "settings.basic.show_dock_icon.label": "在 Dock / 任务栏显示图标",
+  "settings.basic.show_dock_icon.description": "在系统任务栏或 Dock 栏中显示应用程序图标。",
   "settings.basic.shortcut.label": "全局快捷键",
   "settings.basic.shortcut.listening": "监听中...",
   "settings.basic.shortcut.reset": "重置",

--- a/apps/desktop/src/stores/settings.ts
+++ b/apps/desktop/src/stores/settings.ts
@@ -58,7 +58,7 @@ const isMacOS = navigator.userAgent.includes('Macintosh')
 const DEFAULT_STORE = {
   autoselect: false,
   copy_result: false,
-  show_dock_icon: isMacOS ? false : true,
+  show_dock_icon: !isMacOS,
   ai_provider: 'typo' as AI_PROVIDER,
   ai_system_prompt: SYSTEM_PROMPT,
   deepseek_api_key: '',

--- a/apps/desktop/src/stores/settings.ts
+++ b/apps/desktop/src/stores/settings.ts
@@ -53,9 +53,12 @@ export const DEFAULT_SLASH_COMMANDS: SlashCommand[] = [
 
 export const DEFAULT_GLOBAL_SHORTCUT = 'CommandOrControl+Shift+X'
 
+const isMacOS = navigator.userAgent.includes('Macintosh')
+
 const DEFAULT_STORE = {
   autoselect: false,
   copy_result: false,
+  show_dock_icon: isMacOS ? false : true,
   ai_provider: 'typo' as AI_PROVIDER,
   ai_system_prompt: SYSTEM_PROMPT,
   deepseek_api_key: '',


### PR DESCRIPTION
## Summary
- Added `show_dock_icon` setting to the basic settings store with platform-specific defaults.
- Implemented Rust backend command `set_dock_icon_visible` to dynamically toggle Dock (macOS) and Taskbar (Windows/Linux) icon visibility across all managed windows.
- Optimized startup flow to synchronously load settings store and apply macOS activation policy prior to window creation, avoiding any dock icon flickering or blank icon issues.
- Added a toggle switch in the "Basic Settings" UI and updated localizations (en, zh, jp).

## Test plan
- [ ] Open Settings -> Basic and toggle "Show icon in Dock / Taskbar".
- [ ] Verify the icon appears/disappears in the system taskbar or dock.
- [ ] Restart the application and verify the setting is persisted and applied correctly on startup.