### PR TITLE
♻️ [desktop]: Centralize 401 handling and improve device auth UX

### DIFF
--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -6,6 +6,8 @@ import { logger } from '@/logger'
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://app.typo.yuler.cc'
 
+const { t } = useI18n()
+
 let userAgentPromise: Promise<string> | null = null
 let isResetting = false
 
@@ -66,7 +68,6 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
           const { useAuth } = await import('@/composables/useAuth')
           const auth = useAuth()
           if (auth.isLoggedIn.value) {
-            const { t } = useI18n()
             toast.error(t('auth.session_expired'))
             await auth.reset()
           }

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -32,6 +32,11 @@ function getUserAgent(): Promise<string> {
   return userAgentPromise
 }
 
+const ALLOW_UNAUTHORIZED_APIS = [
+  '/api/v1/session',
+  '/api/v1/device',
+]
+
 export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   const userAgent = await getUserAgent()
   const url = `${API_BASE_URL}${path}`
@@ -58,7 +63,7 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
     headers,
   })
 
-  if (response.status === 401 && path !== '/api/v1/session' && !path.startsWith('/api/v1/device/')) {
+  if (response.status === 401 && !ALLOW_UNAUTHORIZED_APIS.some(u => path.startsWith(u))) {
     if (!isResetting) {
       isResetting = true
       try {

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -32,7 +32,7 @@ function getUserAgent(): Promise<string> {
   return userAgentPromise
 }
 
-function is401ResetExempt(path: string, method: string): boolean {
+function allowUnauthenticatedAccess(path: string, method: string): boolean {
   const normalizedPath = path.split('?')[0]
   const exemptions = [
     { method: 'POST', path: '/api/v1/device/authorization' },
@@ -70,7 +70,7 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
     headers,
   })
 
-  if (response.status === 401 && !is401ResetExempt(path, method)) {
+  if (response.status === 401 && !allowUnauthenticatedAccess(path, method)) {
     if (!isResetting) {
       isResetting = true
       try {

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -32,15 +32,17 @@ function getUserAgent(): Promise<string> {
   return userAgentPromise
 }
 
+const AUTH_EXEMPTIONS = [
+  { method: 'POST', path: '/api/v1/device/authorization' },
+  { method: 'POST', path: '/api/v1/device/token' },
+  { method: 'DELETE', path: '/api/v1/session' },
+] as const
+
 function allowUnauthenticatedAccess(path: string, method: string): boolean {
   const normalizedPath = path.split('?')[0]
-  const exemptions = [
-    { method: 'POST', path: '/api/v1/device/authorization' },
-    { method: 'POST', path: '/api/v1/device/token' },
-    { method: 'DELETE', path: '/api/v1/session' },
-  ]
-  return exemptions.some(
-    e => e.path === normalizedPath && e.method.toUpperCase() === method.toUpperCase(),
+  const upperMethod = method.toUpperCase()
+  return AUTH_EXEMPTIONS.some(
+    e => e.path === normalizedPath && e.method === upperMethod,
   )
 }
 

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -1,10 +1,13 @@
 import { invoke } from '@tauri-apps/api/core'
 import { fetch } from '@tauri-apps/plugin-http'
+import { toast } from 'vue-sonner'
+import { useI18n } from '@/composables/useI18n'
 import { logger } from '@/logger'
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://app.typo.yuler.cc'
 
 let userAgentPromise: Promise<string> | null = null
+let isResetting = false
 
 function getUserAgent(): Promise<string> {
   if (userAgentPromise)
@@ -54,6 +57,30 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
     ...options,
     headers,
   })
+
+  if (response.status === 401) {
+    if (path !== '/api/v1/session' && !path.startsWith('/api/v1/device/')) {
+      if (!isResetting) {
+        isResetting = true
+        try {
+          const { useAuth } = await import('@/composables/useAuth')
+          const auth = useAuth()
+          if (auth.isLoggedIn.value) {
+            const { t } = useI18n()
+            toast.error(t('auth.session_expired'))
+            await auth.reset()
+          }
+        }
+        catch (err) {
+          logger.error('api', 'Failed to reset auth state', err)
+        }
+        finally {
+          isResetting = false
+        }
+      }
+    }
+    throw new Error('Unauthorized')
+  }
 
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -32,10 +32,17 @@ function getUserAgent(): Promise<string> {
   return userAgentPromise
 }
 
-const ALLOW_UNAUTHORIZED_APIS = [
-  '/api/v1/session',
-  '/api/v1/device',
-]
+function is401ResetExempt(path: string, method: string): boolean {
+  const normalizedPath = path.split('?')[0]
+  const exemptions = [
+    { method: 'POST', path: '/api/v1/device/authorization' },
+    { method: 'POST', path: '/api/v1/device/token' },
+    { method: 'DELETE', path: '/api/v1/session' },
+  ]
+  return exemptions.some(
+    e => e.path === normalizedPath && e.method.toUpperCase() === method.toUpperCase(),
+  )
+}
 
 export async function api<T>(path: string, options?: RequestInit): Promise<T> {
   const userAgent = await getUserAgent()
@@ -63,7 +70,7 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
     headers,
   })
 
-  if (response.status === 401 && !ALLOW_UNAUTHORIZED_APIS.some(u => path.startsWith(u))) {
+  if (response.status === 401 && !is401ResetExempt(path, method)) {
     if (!isResetting) {
       isResetting = true
       try {

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -6,8 +6,6 @@ import { logger } from '@/logger'
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://app.typo.yuler.cc'
 
-const { t } = useI18n()
-
 let userAgentPromise: Promise<string> | null = null
 let isResetting = false
 
@@ -60,27 +58,25 @@ export async function api<T>(path: string, options?: RequestInit): Promise<T> {
     headers,
   })
 
-  if (response.status === 401) {
-    if (path !== '/api/v1/session' && !path.startsWith('/api/v1/device/')) {
-      if (!isResetting) {
-        isResetting = true
-        try {
-          const { useAuth } = await import('@/composables/useAuth')
-          const auth = useAuth()
-          if (auth.isLoggedIn.value) {
-            toast.error(t('auth.session_expired'))
-            await auth.reset()
-          }
-        }
-        catch (err) {
-          logger.error('api', 'Failed to reset auth state', err)
-        }
-        finally {
-          isResetting = false
+  if (response.status === 401 && path !== '/api/v1/session' && !path.startsWith('/api/v1/device/')) {
+    if (!isResetting) {
+      isResetting = true
+      try {
+        const { useAuth } = await import('@/composables/useAuth')
+        const auth = useAuth()
+        if (auth.isLoggedIn.value) {
+          const { t } = useI18n()
+          toast.error(t('auth.session_expired'))
+          await auth.reset()
         }
       }
+      catch (err) {
+        logger.error('api', 'Failed to reset auth state', err)
+      }
+      finally {
+        isResetting = false
+      }
     }
-    throw new Error('Unauthorized')
   }
 
   if (!response.ok) {

--- a/apps/desktop/src/components/DeviceAuthModal.vue
+++ b/apps/desktop/src/components/DeviceAuthModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { openUrl } from '@tauri-apps/plugin-opener'
 import { ExternalLink, Loader2 } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { Button } from '@/components/ui/button'
@@ -24,7 +25,6 @@ const isOpen = computed({
 
 async function openBrowser() {
   if (deviceCode.value) {
-    const { openUrl } = await import('@tauri-apps/plugin-opener')
     await openUrl(deviceCode.value.verification_uri)
   }
 }

--- a/apps/desktop/src/components/DeviceAuthModal.vue
+++ b/apps/desktop/src/components/DeviceAuthModal.vue
@@ -25,18 +25,14 @@ const isOpen = computed({
 })
 
 const copied = ref(false)
-let copyCount = 0
 
 async function copyLink() {
   if (deviceCode.value) {
     try {
       await navigator.clipboard.writeText(deviceCode.value.verification_uri)
       copied.value = true
-      const currentCount = ++copyCount
       await sleep(2000)
-      if (currentCount === copyCount) {
-        copied.value = false
-      }
+      copied.value = false
     }
     catch (err) {
       console.error('Failed to copy link:', err)

--- a/apps/desktop/src/components/DeviceAuthModal.vue
+++ b/apps/desktop/src/components/DeviceAuthModal.vue
@@ -25,13 +25,22 @@ const isOpen = computed({
 })
 
 const copied = ref(false)
+let copyCount = 0
 
 async function copyLink() {
   if (deviceCode.value) {
-    await navigator.clipboard.writeText(deviceCode.value.verification_uri)
-    copied.value = true
-    await sleep(2000)
-    copied.value = false
+    try {
+      await navigator.clipboard.writeText(deviceCode.value.verification_uri)
+      copied.value = true
+      const currentCount = ++copyCount
+      await sleep(2000)
+      if (currentCount === copyCount) {
+        copied.value = false
+      }
+    }
+    catch (err) {
+      console.error('Failed to copy link:', err)
+    }
   }
 }
 

--- a/apps/desktop/src/components/DeviceAuthModal.vue
+++ b/apps/desktop/src/components/DeviceAuthModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { ExternalLink, Loader2 } from 'lucide-vue-next'
-import { computed } from 'vue'
+import { Check, Copy, ExternalLink, Loader2 } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { useAuth } from '@/composables/useAuth'
+import { sleep } from '@/utils'
 
 const { authStatus, deviceCode, cancel } = useAuth()
 
@@ -22,6 +23,17 @@ const isOpen = computed({
       cancel()
   },
 })
+
+const copied = ref(false)
+
+async function copyLink() {
+  if (deviceCode.value) {
+    await navigator.clipboard.writeText(deviceCode.value.verification_uri)
+    copied.value = true
+    await sleep(2000)
+    copied.value = false
+  }
+}
 
 async function openBrowser() {
   if (deviceCode.value) {
@@ -45,9 +57,27 @@ async function openBrowser() {
           Please enter the code below on your other device to log in.
         </DialogDescription>
       </DialogHeader>
-      <div class="flex flex-col items-center justify-center py-8 space-y-8">
+      <div class="flex flex-col items-center justify-center py-8 space-y-6">
         <div v-if="deviceCode" class="bg-muted/50 border-2 border-dashed border-primary/30 rounded-2xl px-16 py-8 text-5xl font-mono font-bold tracking-[0.25em] text-primary shadow-sm">
           {{ deviceCode.user_code }}
+        </div>
+
+        <div v-if="deviceCode" class="flex flex-col items-center gap-1.5 w-full text-center">
+          <div class="flex items-center gap-1.5 justify-center max-w-full px-4">
+            <span class="font-mono text-xs text-muted-foreground truncate select-all">
+              {{ deviceCode.verification_uri }}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              class="h-7 w-7 text-muted-foreground hover:text-foreground shrink-0 rounded-md hover:bg-accent/40"
+              title="Copy link"
+              @click="copyLink"
+            >
+              <Check v-if="copied" class="h-3.5 w-3.5 text-emerald-500 animate-in fade-in zoom-in-50 duration-200" />
+              <Copy v-else class="h-3.5 w-3.5 transition-transform active:scale-95 duration-200" />
+            </Button>
+          </div>
         </div>
 
         <div class="flex items-center gap-2 text-base text-muted-foreground">
@@ -55,11 +85,12 @@ async function openBrowser() {
           Waiting for authorization...
         </div>
       </div>
+
       <DialogFooter class="flex items-center justify-end gap-3 pt-2">
         <Button variant="ghost" class="text-muted-foreground" @click="cancel">
           Cancel
         </Button>
-        <Button variant="default" class="gap-2 px-6" @click="openBrowser">
+        <Button v-if="deviceCode" variant="default" class="gap-2 px-6" @click="openBrowser">
           <ExternalLink class="h-4 w-4" />
           Open Browser
         </Button>

--- a/apps/desktop/src/composables/useAuth.ts
+++ b/apps/desktop/src/composables/useAuth.ts
@@ -1,8 +1,6 @@
 import { createGlobalState } from '@vueuse/core'
 import { ref } from 'vue'
-import { toast } from 'vue-sonner'
 import { api } from '@/api'
-import { useI18n } from '@/composables/useI18n'
 import { logger } from '@/logger'
 import * as authStore from '@/stores/auth'
 import { gravatar } from '@/utils'
@@ -27,7 +25,6 @@ export const useAuth = createGlobalState(() => {
     avatar_url: '',
   })
 
-  const { t } = useI18n()
   const HEARTBEAT_INTERVAL = 2 * 60 * 1000 // 2 minutes
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let heartbeatTimer: ReturnType<typeof setTimeout> | null = null
@@ -75,11 +72,6 @@ export const useAuth = createGlobalState(() => {
         }
       }
       catch (err: any) {
-        if (err?.message?.includes('401') || err?.message === 'Unauthorized') {
-          toast.error(t('auth.session_expired'))
-          await logout()
-          return
-        }
         logger.error('Auth', 'Heartbeat failed', err)
       }
 
@@ -210,6 +202,20 @@ export const useAuth = createGlobalState(() => {
     await authStore.saveAuth()
   }
 
+  async function reset() {
+    stopHeartbeat()
+    cancel()
+    isLoggedIn.value = false
+    user.value = {
+      name: '',
+      email: '',
+      avatar_url: '',
+    }
+    await authStore.setAuth('access_token', '')
+    await authStore.setAuth('email', '')
+    await authStore.saveAuth()
+  }
+
   function cancel() {
     if (pollTimer)
       clearTimeout(pollTimer)
@@ -227,5 +233,6 @@ export const useAuth = createGlobalState(() => {
     login,
     logout,
     cancel,
+    reset,
   }
 })

--- a/apps/desktop/src/composables/useAuth.ts
+++ b/apps/desktop/src/composables/useAuth.ts
@@ -175,8 +175,6 @@ export const useAuth = createGlobalState(() => {
   }
 
   async function logout() {
-    stopHeartbeat()
-    cancel()
     const token = await authStore.getAuth('access_token')
     if (token) {
       try {
@@ -191,15 +189,7 @@ export const useAuth = createGlobalState(() => {
         logger.error('Auth', 'Failed to remove session on server', err)
       }
     }
-    isLoggedIn.value = false
-    user.value = {
-      name: '',
-      email: '',
-      avatar_url: '',
-    }
-    await authStore.setAuth('access_token', '')
-    await authStore.setAuth('email', '')
-    await authStore.saveAuth()
+    await reset()
   }
 
   async function reset() {


### PR DESCRIPTION
## Summary
- **Centralized and simplified `401 Unauthorized` handling**: Moved unauthorized session handling from the heartbeat poll into the core `api` helper, allowing global session expiration handling across all API requests. Cleaned up the file by removing the unused top-level `useI18n` initialization.
- **Dedicated local auth state reset**: Added a safe `reset()` method in the `useAuth` composable to clean up reactive states, clear local storage (`auth.json`), and halt timers/heartbeats without initiating a remote logout request.
- **Prevented recursive reset loops**: Introduced an `isResetting` guard and bypassed reset logic on session/device authentication endpoints to avoid recursive cycles.
- **Improved Device Auth Modal UX**:
  - Added a copy-to-clipboard button and interactive link for the verification URI in `DeviceAuthModal.vue` for seamless text copying.
  - Added subtle animations (fade-in, zoom-in, scale) for immediate visual copy feedback.
  - Conditionally rendered the "Open Browser" button only when `deviceCode` exists to avoid errors.
- **Optimized translation initialization**: Deferred `useI18n()` instantiation in `api.ts` to execute lazily only within the unauthorized interceptor path.

## Test plan
- [x] Verified that any standard API call returning `401 Unauthorized` triggers the global toast and gracefully resets the local auth state.
- [x] Verified that the local `auth.json` store and reactive states are correctly cleared upon session expiration.
- [x] Tested the clipboard functionality in `DeviceAuthModal.vue` to ensure copying the verification link works and triggers the animated checkmark feedback.
- [x] Verified that the "Open Browser" button is hidden when no device code is present.