### PR TITLE
✨ Add GET /api/v1/session and deprecate session heartbeat

### DIFF
--- a/apps/desktop/src/composables/useAuth.ts
+++ b/apps/desktop/src/composables/useAuth.ts
@@ -25,10 +25,10 @@ export const useAuth = createGlobalState(() => {
     avatar_url: '',
   })
 
-  const HEARTBEAT_INTERVAL = 2 * 60 * 1000 // 2 minutes
+  const SESSION_SYNC_INTERVAL = 2 * 60 * 1000 // 2 minutes
   let pollTimer: ReturnType<typeof setTimeout> | null = null
-  let heartbeatTimer: ReturnType<typeof setTimeout> | null = null
-  let heartbeatGeneration = 0
+  let sessionSyncTimer: ReturnType<typeof setTimeout> | null = null
+  let sessionSyncGeneration = 0
 
   async function initialize() {
     const token = await authStore.getAuth('access_token')
@@ -40,29 +40,29 @@ export const useAuth = createGlobalState(() => {
         email: userEmail,
         avatar_url: await gravatar(userEmail),
       }
-      startHeartbeat()
+      startSessionSync()
     }
   }
 
-  async function startHeartbeat() {
-    stopHeartbeat()
-    const generation = ++heartbeatGeneration
+  async function startSessionSync() {
+    stopSessionSync()
+    const generation = ++sessionSyncGeneration
 
-    const performHeartbeat = async () => {
+    const performSessionSync = async () => {
       const token = await authStore.getAuth('access_token')
-      if (!token || !isLoggedIn.value || generation !== heartbeatGeneration)
+      if (!token || !isLoggedIn.value || generation !== sessionSyncGeneration)
         return
 
       try {
-        const data = await api<{ name: string, email: string, avatar_url: string | null }>('/api/v1/session/heartbeat', {
+        const data = await api<{ name: string, email: string, avatar_url: string | null }>('/api/v1/session', {
           headers: { Authorization: `Bearer ${token}` },
         })
 
-        if (!isLoggedIn.value || generation !== heartbeatGeneration)
+        if (!isLoggedIn.value || generation !== sessionSyncGeneration)
           return
 
         const avatar_url = data.avatar_url || (data.email === user.value.email ? user.value.avatar_url : await gravatar(data.email))
-        if (!isLoggedIn.value || generation !== heartbeatGeneration)
+        if (!isLoggedIn.value || generation !== sessionSyncGeneration)
           return
 
         if (data.name !== user.value.name || data.email !== user.value.email || avatar_url !== user.value.avatar_url) {
@@ -72,22 +72,22 @@ export const useAuth = createGlobalState(() => {
         }
       }
       catch (err: any) {
-        logger.error('Auth', 'Heartbeat failed', err)
+        logger.error('Auth', 'Session sync failed', err)
       }
 
-      if (isLoggedIn.value && generation === heartbeatGeneration) {
-        heartbeatTimer = setTimeout(performHeartbeat, HEARTBEAT_INTERVAL)
+      if (isLoggedIn.value && generation === sessionSyncGeneration) {
+        sessionSyncTimer = setTimeout(performSessionSync, SESSION_SYNC_INTERVAL)
       }
     }
 
-    await performHeartbeat()
+    await performSessionSync()
   }
 
-  function stopHeartbeat() {
-    heartbeatGeneration++
-    if (heartbeatTimer) {
-      clearTimeout(heartbeatTimer)
-      heartbeatTimer = null
+  function stopSessionSync() {
+    sessionSyncGeneration++
+    if (sessionSyncTimer) {
+      clearTimeout(sessionSyncTimer)
+      sessionSyncTimer = null
     }
   }
 
@@ -169,7 +169,7 @@ export const useAuth = createGlobalState(() => {
     await authStore.setAuth('access_token', token)
     await authStore.setAuth('email', identity.email)
     await authStore.saveAuth()
-    startHeartbeat()
+    startSessionSync()
     if (pollTimer)
       clearTimeout(pollTimer)
   }
@@ -193,7 +193,7 @@ export const useAuth = createGlobalState(() => {
   }
 
   async function reset() {
-    stopHeartbeat()
+    stopSessionSync()
     cancel()
     isLoggedIn.value = false
     user.value = {

--- a/core/app/controllers/api/v1/sessions/heartbeats_controller.rb
+++ b/core/app/controllers/api/v1/sessions/heartbeats_controller.rb
@@ -1,12 +1,10 @@
+# Deprecated: remove in API v2 — clients should use GET /api/v1/session instead.
 class Api::V1::Sessions::HeartbeatsController < Api::V1::BaseController
+  include SessionIdentity
+
   skip_account_scope
 
   def show
-    Current.session.update!(last_active_at: Time.current)
-    render json: {
-      name: Current.identity.display_name,
-      email: Current.identity.email,
-      avatar_url: nil # Extend later if identity/user gains an avatar field
-    }
+    render_session_identity
   end
 end

--- a/core/app/controllers/api/v1/sessions_controller.rb
+++ b/core/app/controllers/api/v1/sessions_controller.rb
@@ -1,5 +1,11 @@
 class Api::V1::SessionsController < Api::V1::BaseController
+  include SessionIdentity
+
   skip_account_scope
+
+  def show
+    render_session_identity
+  end
 
   def destroy
     Current.session&.destroy

--- a/core/app/controllers/concerns/session_identity.rb
+++ b/core/app/controllers/concerns/session_identity.rb
@@ -1,0 +1,13 @@
+module SessionIdentity
+  extend ActiveSupport::Concern
+
+  private
+    def render_session_identity
+      Current.session.update!(last_active_at: Time.current)
+      render json: {
+        name: Current.identity.display_name,
+        email: Current.identity.email,
+        avatar_url: nil
+      }
+    end
+end

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -40,9 +40,9 @@ Rails.application.routes.draw do
       resources :completions, only: :create
       resources :slash_prompts, only: %i[ index create update destroy ]
       resource :default_prompt, only: %i[ show update ]
-      resource :session, only: :destroy do
+      resource :session, only: %i[show destroy] do
         scope module: :sessions do
-          resource :heartbeat, only: :show
+          resource :heartbeat, only: :show # deprecated: remove in API v2 — use GET /api/v1/session
         end
       end
       resource :stats, only: :show

--- a/core/test/controllers/api/v1/sessions/heartbeats_controller_test.rb
+++ b/core/test/controllers/api/v1/sessions/heartbeats_controller_test.rb
@@ -26,4 +26,16 @@ class Api::V1::Sessions::HeartbeatsControllerTest < ActionDispatch::IntegrationT
     get api_v1_session_heartbeat_url, headers: { Authorization: "Bearer invalid_token" }
     assert_response :unauthorized
   end
+
+  test "heartbeat matches session show response" do
+    get api_v1_session_url, headers: { Authorization: "Bearer #{@token}" }
+    assert_response :success
+    show_json = JSON.parse(response.body)
+
+    get api_v1_session_heartbeat_url, headers: { Authorization: "Bearer #{@token}" }
+    assert_response :success
+    heartbeat_json = JSON.parse(response.body)
+
+    assert_equal show_json, heartbeat_json
+  end
 end

--- a/core/test/controllers/api/v1/sessions_controller_test.rb
+++ b/core/test/controllers/api/v1/sessions_controller_test.rb
@@ -19,4 +19,25 @@ class Api::V1::SessionsControllerTest < ActionDispatch::IntegrationTest
     delete api_v1_session_url, as: :json
     assert_response :unauthorized
   end
+
+  test "should show session and update last_active_at" do
+    assert_changes -> { @session.reload.last_active_at } do
+      get api_v1_session_url, headers: { "Authorization" => "Bearer #{@session.signed_id}" }
+    end
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal @identity.email, json["email"]
+    assert_equal @identity.display_name, json["name"]
+    assert_nil json["avatar_url"]
+  end
+
+  test "should return unauthorized for show without token" do
+    get api_v1_session_url
+    assert_response :unauthorized
+  end
+
+  test "should return unauthorized for show with invalid token" do
+    get api_v1_session_url, headers: { "Authorization" => "Bearer invalid_token" }
+    assert_response :unauthorized
+  end
 end


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/session` as the canonical session read endpoint (updates `last_active_at`, returns identity JSON)
- Extract shared `SessionIdentity` concern; keep `GET /api/v1/session/heartbeat` as a deprecated alias for API v2 removal
- Migrate desktop auth polling to `GET /api/v1/session` and rename heartbeat helpers to session sync

## Test plan
- [x] `bin/rails test` for `sessions_controller_test` and `heartbeats_controller_test` (9 runs, 0 failures)
- [ ] Desktop: log in, confirm session stays valid and user info syncs after ~2 minutes

Made with [Cursor](https://cursor.com)