### PR TITLE
✨ [core]: Completion history API with geared pagination

### DIFF
--- a/core/Gemfile
+++ b/core/Gemfile
@@ -32,6 +32,8 @@ gem "image_processing", "~> 1.2"
 
 # Features
 # gem "commonmarker", "~> 2.6"
+gem "ruby_llm"
+gem "geared_pagination"
 
 # Dashboard engines
 gem "mission_control-jobs"
@@ -39,9 +41,6 @@ gem "mission_control-jobs"
 # API
 # gem "jwt"
 gem "jbuilder"
-gem "ruby_llm"
-gem "geared_pagination"
-
 
 # HTTP Clients
 # gem "faraday"

--- a/core/Gemfile
+++ b/core/Gemfile
@@ -40,6 +40,7 @@ gem "mission_control-jobs"
 # gem "jwt"
 gem "jbuilder"
 gem "ruby_llm"
+gem "geared_pagination"
 
 
 # HTTP Clients

--- a/core/Gemfile.lock
+++ b/core/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
     fugit (1.12.1)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
+    geared_pagination (1.2.0)
+      activesupport (>= 5.0)
+      addressable (>= 2.5.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -426,6 +429,7 @@ DEPENDENCIES
   capybara
   debug
   dotenv-rails
+  geared_pagination
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/core/app/controllers/api/v1/base_controller.rb
+++ b/core/app/controllers/api/v1/base_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::BaseController < ActionController::API
   include ApiAuthentication
   include Authorization
   include CurrentRequest
+  include GearedPagination::Controller
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
     render json: { error: exception.message }, status: :not_found

--- a/core/app/controllers/api/v1/base_controller.rb
+++ b/core/app/controllers/api/v1/base_controller.rb
@@ -2,7 +2,6 @@ class Api::V1::BaseController < ActionController::API
   include ApiAuthentication
   include Authorization
   include CurrentRequest
-  include GearedPagination::Controller
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
     render json: { error: exception.message }, status: :not_found

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -9,9 +9,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
 
   def index
     completions = Completion.where(account: Current.account).ordered
-    records = set_page_and_extract_portion_from(completions)
-
-    render json: records.as_json(only: [ :id, :input, :output, :prompt, :prompt_key, :status, :created_at ])
+    set_page_and_extract_portion_from(completions)
   end
 
   def destroy

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::CompletionsController < Api::V1::BaseController
-  include GearedPagination::Controller
-
   allow_unauthenticated_access only: :create
   skip_account_scope only: :create
 
@@ -8,7 +6,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
   before_action :check_rate_limit, only: :create
 
   def index
-    completions = Completion.where(account_id: Current.account.id).order(created_at: :desc)
+    completions = Completion.where(account: Current.account).ordered
     records = set_page_and_extract_portion_from(completions)
 
     render json: {
@@ -22,7 +20,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
   end
 
   def destroy
-    completion = Completion.where(account_id: Current.account.id).find(params[:id])
+    completion = Completion.where(account: Current.account).find(params[:id])
     completion.destroy!
     head :no_content
   end
@@ -37,7 +35,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
       account: account,
       user: user,
       prompt: @ai_completion.prompt,
-      prompt_key: params[:prompt_key].presence || "/default",
+      prompt_key: params[:prompt_key].presence,
       input: @ai_completion.text,
       status: "pending"
     )

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -9,14 +9,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
     completions = Completion.where(account: Current.account).ordered
     records = set_page_and_extract_portion_from(completions)
 
-    render json: {
-      completions: records.as_json(only: [ :id, :input, :output, :prompt, :prompt_key, :status, :created_at ]),
-      meta: {
-        page: @page.number,
-        next_page: @page.last? ? nil : @page.next_param,
-        has_more: !@page.last?
-      }
-    }
+    render json: records.as_json(only: [ :id, :input, :output, :prompt, :prompt_key, :status, :created_at ])
   end
 
   def destroy

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -1,9 +1,29 @@
 class Api::V1::CompletionsController < Api::V1::BaseController
-  allow_unauthenticated_access
-  skip_account_scope
+  allow_unauthenticated_access only: :create
+  skip_account_scope only: :create
 
-  before_action :validate_params!
-  before_action :check_rate_limit
+  before_action :validate_params!, only: :create
+  before_action :check_rate_limit, only: :create
+
+  def index
+    completions = Completion.where(account_id: Current.account.id).order(created_at: :desc)
+    records = set_page_and_extract_portion_from(completions)
+
+    render json: {
+      completions: records.as_json(only: [:id, :input, :output, :prompt, :prompt_key, :status, :created_at]),
+      meta: {
+        page: @page.number,
+        next_page: @page.last? ? nil : @page.next_param,
+        has_more: !@page.last?
+      }
+    }
+  end
+
+  def destroy
+    completion = Completion.where(account_id: Current.account.id).find(params[:id])
+    completion.destroy!
+    head :no_content
+  end
 
   def create
     if authenticated?
@@ -15,6 +35,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
       account: account,
       user: user,
       prompt: @ai_completion.prompt,
+      prompt_key: params[:prompt_key].presence || "/default",
       input: @ai_completion.text,
       status: "pending"
     )

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::CompletionsController < Api::V1::BaseController
+  include GearedPagination::Controller
+
   allow_unauthenticated_access only: :create
   skip_account_scope only: :create
 
@@ -25,12 +27,14 @@ class Api::V1::CompletionsController < Api::V1::BaseController
     end
 
     completion = Completion.create!(
-      account: account,
-      user: user,
-      prompt: @ai_completion.prompt,
-      prompt_key: params[:prompt_key].presence,
-      input: @ai_completion.text,
-      status: "pending"
+      {
+        account: account,
+        user: user,
+        prompt: @ai_completion.prompt,
+        input: @ai_completion.text,
+        status: "pending",
+        prompt_key: params[:prompt_key].presence
+      }.compact
     )
 
     result = @ai_completion.perform

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::CompletionsController < Api::V1::BaseController
+  include GearedPagination::Controller
+
   allow_unauthenticated_access only: :create
   skip_account_scope only: :create
 

--- a/core/app/controllers/api/v1/completions_controller.rb
+++ b/core/app/controllers/api/v1/completions_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::CompletionsController < Api::V1::BaseController
     records = set_page_and_extract_portion_from(completions)
 
     render json: {
-      completions: records.as_json(only: [:id, :input, :output, :prompt, :prompt_key, :status, :created_at]),
+      completions: records.as_json(only: [ :id, :input, :output, :prompt, :prompt_key, :status, :created_at ]),
       meta: {
         page: @page.number,
         next_page: @page.last? ? nil : @page.next_param,

--- a/core/app/models/completion.rb
+++ b/core/app/models/completion.rb
@@ -4,5 +4,4 @@ class Completion < ApplicationRecord
 
   validates :input, presence: true
   validates :status, presence: true
-  validates :prompt_key, presence: true
 end

--- a/core/app/models/completion.rb
+++ b/core/app/models/completion.rb
@@ -4,4 +4,5 @@ class Completion < ApplicationRecord
 
   validates :input, presence: true
   validates :status, presence: true
+  validates :prompt_key, presence: true
 end

--- a/core/app/models/completion.rb
+++ b/core/app/models/completion.rb
@@ -4,4 +4,6 @@ class Completion < ApplicationRecord
 
   validates :input, presence: true
   validates :status, presence: true
+
+  scope :ordered, -> { order(created_at: :desc) }
 end

--- a/core/app/views/api/v1/completions/_completion.json.jbuilder
+++ b/core/app/views/api/v1/completions/_completion.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! completion, :id, :input, :output, :prompt, :prompt_key, :duration_ms, :status, :created_at

--- a/core/app/views/api/v1/completions/index.json.jbuilder
+++ b/core/app/views/api/v1/completions/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @page.records, partial: "api/v1/completions/completion", as: :completion

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
   # API
   namespace :api do
     namespace :v1, defaults: { format: :json } do
-      resources :completions, only: :create
+      resources :completions, only: [ :create, :index, :destroy ]
       resources :slash_prompts, only: %i[ index create update destroy ]
       resource :default_prompt, only: %i[ show update ]
       resource :session, only: :destroy do

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
   # API
   namespace :api do
     namespace :v1, defaults: { format: :json } do
-      resources :completions, only: [ :create, :index, :destroy ]
+      resources :completions, only: %i[ create index destroy ]
       resources :slash_prompts, only: %i[ index create update destroy ]
       resource :default_prompt, only: %i[ show update ]
       resource :session, only: :destroy do

--- a/core/db/migrate/20260521025500_add_prompt_key_to_completions.rb
+++ b/core/db/migrate/20260521025500_add_prompt_key_to_completions.rb
@@ -1,5 +1,5 @@
 class AddPromptKeyToCompletions < ActiveRecord::Migration[8.2]
   def change
-    add_column :completions, :prompt_key, :string
+    add_column :completions, :prompt_key, :string, null: false, default: "/default"
   end
 end

--- a/core/db/migrate/20260521025500_add_prompt_key_to_completions.rb
+++ b/core/db/migrate/20260521025500_add_prompt_key_to_completions.rb
@@ -1,0 +1,5 @@
+class AddPromptKeyToCompletions < ActiveRecord::Migration[8.2]
+  def change
+    add_column :completions, :prompt_key, :string
+  end
+end

--- a/core/db/schema.rb
+++ b/core/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_05_20_130000) do
+ActiveRecord::Schema[8.2].define(version: 2026_05_21_025500) do
   create_table "accounts", id: :uuid, force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
@@ -29,6 +29,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_20_130000) do
     t.string "model"
     t.text "output"
     t.text "prompt"
+    t.string "prompt_key"
     t.string "status", default: "success", null: false
     t.json "tokens"
     t.datetime "updated_at", null: false

--- a/core/db/schema.rb
+++ b/core/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_05_21_025500) do
     t.string "model"
     t.text "output"
     t.text "prompt"
-    t.string "prompt_key"
+    t.string "prompt_key", default: "/default", null: false
     t.string "status", default: "success", null: false
     t.json "tokens"
     t.datetime "updated_at", null: false

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -92,6 +92,7 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     completion = Completion.last
     assert_nil completion.account
     assert_nil completion.user
+    assert_equal "/default", completion.prompt_key
     assert_equal "anonymous text", completion.input
     assert_equal "pending", completion.status
 
@@ -100,5 +101,74 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     completion.reload
     assert_equal "__success__", completion.output
     assert_equal "success", completion.status
+  end
+
+  test "index unauthenticated should return unauthorized" do
+    get api_v1_completions_url, as: :json
+    assert_response :unauthorized
+  end
+
+  test "index authenticated returns paginated completions for current account" do
+    account = Account.create!(name: "Personal", personal: true)
+    identity = Identity.create!(email: "test@example.com")
+    identity.users.create!(account: account, role: :owner, name: "Test User")
+    token = identity.signed_id(purpose: :api_token)
+
+    # Create completions belonging to this account
+    Completion.create!(account: account, input: "text 1", output: "out 1", prompt_key: "/default", status: "success")
+    Completion.create!(account: account, input: "text 2", output: "out 2", prompt_key: "/default", status: "success")
+
+    # Create completion belonging to another account
+    other_account = Account.create!(name: "Other", personal: true)
+    other_identity = Identity.create!(email: "other@example.com")
+    other_identity.users.create!(account: other_account, role: :owner, name: "Other User")
+    Completion.create!(account: other_account, input: "other text", output: "other out", prompt_key: "/default", status: "success")
+
+    get api_v1_completions_url, headers: { "Authorization" => "Bearer #{token}" }, as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal 2, body["completions"].size
+    assert_equal "text 2", body["completions"][0]["input"] # descending order
+    assert_equal "text 1", body["completions"][1]["input"]
+    assert_nil body["meta"]["next_page"]
+    assert_equal false, body["meta"]["has_more"]
+  end
+
+  test "destroy unauthenticated should return unauthorized" do
+    account = Account.create!(name: "Personal", personal: true)
+    completion = Completion.create!(account: account, input: "text 1", output: "out 1", prompt_key: "/default", status: "success")
+
+    delete api_v1_completion_url(completion), as: :json
+    assert_response :unauthorized
+  end
+
+  test "destroy authenticated destroys completion belonging to account" do
+    account = Account.create!(name: "Personal", personal: true)
+    identity = Identity.create!(email: "test@example.com")
+    identity.users.create!(account: account, role: :owner, name: "Test User")
+    token = identity.signed_id(purpose: :api_token)
+
+    completion = Completion.create!(account: account, input: "text 1", output: "out 1", prompt_key: "/default", status: "success")
+
+    assert_difference -> { Completion.count }, -1 do
+      delete api_v1_completion_url(completion), headers: { "Authorization" => "Bearer #{token}" }, as: :json
+    end
+    assert_response :no_content
+  end
+
+  test "destroy authenticated returns 404 for completion belonging to another account" do
+    account = Account.create!(name: "Personal", personal: true)
+    identity = Identity.create!(email: "test@example.com")
+    identity.users.create!(account: account, role: :owner, name: "Test User")
+    token = identity.signed_id(purpose: :api_token)
+
+    other_account = Account.create!(name: "Other", personal: true)
+    completion = Completion.create!(account: other_account, input: "text 1", output: "out 1", prompt_key: "/default", status: "success")
+
+    assert_no_difference -> { Completion.count } do
+      delete api_v1_completion_url(completion), headers: { "Authorization" => "Bearer #{token}" }, as: :json
+    end
+    assert_response :not_found
   end
 end

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -128,11 +128,11 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     body = JSON.parse(response.body)
-    assert_equal 2, body["completions"].size
-    assert_equal "text 2", body["completions"][0]["input"] # descending order
-    assert_equal "text 1", body["completions"][1]["input"]
-    assert_nil body["meta"]["next_page"]
-    assert_equal false, body["meta"]["has_more"]
+    assert_equal 2, body.size
+    assert_equal "text 2", body[0]["input"] # descending order
+    assert_equal "text 1", body[1]["input"]
+    assert_equal "2", response.headers["X-Total-Count"]
+    assert_nil response.headers["Link"]
   end
 
   test "destroy unauthenticated should return unauthorized" do

--- a/core/test/controllers/api/v1/completions_controller_test.rb
+++ b/core/test/controllers/api/v1/completions_controller_test.rb
@@ -108,30 +108,53 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
-  test "index authenticated returns paginated completions for current account" do
-    account = Account.create!(name: "Personal", personal: true)
-    identity = Identity.create!(email: "test@example.com")
-    identity.users.create!(account: account, role: :owner, name: "Test User")
-    token = identity.signed_id(purpose: :api_token)
+  test "index authenticated returns completions for current account only" do
+    account, token = authenticated_account_and_token
 
-    # Create completions belonging to this account
-    Completion.create!(account: account, input: "text 1", output: "out 1", prompt_key: "/default", status: "success")
-    Completion.create!(account: account, input: "text 2", output: "out 2", prompt_key: "/default", status: "success")
+    create_completion(account, input: "text 1", created_at: 2.minutes.ago)
+    create_completion(account, input: "text 2", created_at: 1.minute.ago)
 
-    # Create completion belonging to another account
     other_account = Account.create!(name: "Other", personal: true)
-    other_identity = Identity.create!(email: "other@example.com")
-    other_identity.users.create!(account: other_account, role: :owner, name: "Other User")
-    Completion.create!(account: other_account, input: "other text", output: "other out", prompt_key: "/default", status: "success")
+    create_completion(other_account, input: "other text")
 
-    get api_v1_completions_url, headers: { "Authorization" => "Bearer #{token}" }, as: :json
+    get api_v1_completions_url, headers: bearer_headers(token), as: :json
     assert_response :success
 
     body = JSON.parse(response.body)
     assert_equal 2, body.size
-    assert_equal "text 2", body[0]["input"] # descending order
+    assert_equal "text 2", body[0]["input"]
     assert_equal "text 1", body[1]["input"]
     assert_equal "2", response.headers["X-Total-Count"]
+    assert_nil response.headers["Link"]
+  end
+
+  test "index geared pagination returns first page of 15 with next Link" do
+    account, token = authenticated_account_and_token
+    create_account_completions(account, 16)
+
+    get api_v1_completions_url, headers: bearer_headers(token), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal 15, body.size
+    assert_equal "text 0", body.first["input"]
+    assert_equal "text 14", body.last["input"]
+    assert_equal "16", response.headers["X-Total-Count"]
+    assert_match(/rel="next"/, response.headers["Link"])
+    assert_match(/page=2/, response.headers["Link"])
+  end
+
+  test "index geared pagination page 2 returns remaining records" do
+    account, token = authenticated_account_and_token
+    create_account_completions(account, 16)
+
+    get api_v1_completions_url(page: 2), headers: bearer_headers(token), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal 1, body.size
+    assert_equal "text 15", body.first["input"]
+    assert_equal "16", response.headers["X-Total-Count"]
     assert_nil response.headers["Link"]
   end
 
@@ -171,4 +194,26 @@ class Api::V1::CompletionsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :not_found
   end
+
+  private
+    def authenticated_account_and_token
+      account = Account.create!(name: "Personal", personal: true)
+      identity = Identity.create!(email: "test-#{SecureRandom.hex(4)}@example.com")
+      identity.users.create!(account: account, role: :owner, name: "Test User")
+      [ account, identity.signed_id(purpose: :api_token) ]
+    end
+
+    def bearer_headers(token)
+      { "Authorization" => "Bearer #{token}" }
+    end
+
+    def create_completion(account, input:, output: "out", created_at: Time.current, **attrs)
+      Completion.create!(
+        { account: account, input: input, output: output, prompt_key: "/default", status: "success", created_at: created_at }.merge(attrs)
+      )
+    end
+
+    def create_account_completions(account, count)
+      count.times { |i| create_completion(account, input: "text #{i}", created_at: i.minutes.ago) }
+    end
 end

--- a/core/test/controllers/api/v1/stats_controller_test.rb
+++ b/core/test/controllers/api/v1/stats_controller_test.rb
@@ -6,7 +6,7 @@ class Api::V1::StatsControllerTest < ActionDispatch::IntegrationTest
     @account = Account.create!(name: "Test Account", personal: true)
     @user = User.create!(identity: @identity, account: @account, name: "Test User", role: "owner")
     @session = @identity.sessions.create!(user_agent: "TestAgent", ip_address: "127.0.0.1")
-    Completion.create!(account: @account, user: @user, input: "test", status: "success")
+    Completion.create!(account: @account, user: @user, input: "test", prompt_key: "/default", status: "success")
   end
 
   test "should get stats when authenticated" do

--- a/core/test/jobs/completion_persistence_job_test.rb
+++ b/core/test/jobs/completion_persistence_job_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class CompletionPersistenceJobTest < ActiveJob::TestCase
   test "updates a completion record" do
     account = Account.create!(name: "Test Account")
-    completion = Completion.create!(account: account, input: "hello", status: "pending")
+    completion = Completion.create!(account: account, input: "hello", prompt_key: "/default", status: "pending")
     attributes = {
       output: "hi",
       status: "success"
@@ -18,7 +18,7 @@ class CompletionPersistenceJobTest < ActiveJob::TestCase
   end
 
   test "logs error on invalid attributes" do
-    completion = Completion.create!(input: "hello", status: "pending")
+    completion = Completion.create!(input: "hello", prompt_key: "/default", status: "pending")
     attributes = { status: nil }
 
     assert_no_difference "Completion.count" do

--- a/core/test/models/completion_test.rb
+++ b/core/test/models/completion_test.rb
@@ -8,6 +8,7 @@ class CompletionTest < ActiveSupport::TestCase
       input: "hello",
       output: "hi",
       prompt: "be helpful",
+      prompt_key: "/default",
       model: "test-model",
       tokens: { total: 10 },
       duration_ms: 100,
@@ -20,6 +21,7 @@ class CompletionTest < ActiveSupport::TestCase
     account = Account.create!(name: "Test Account")
     completion = Completion.new(
       account: account,
+      prompt_key: "/default",
       status: "success"
     )
     assert_not completion.valid?


### PR DESCRIPTION
## Summary
- Add authenticated `GET /api/v1/completions` and `DELETE /api/v1/completions/:id`, scoped to the current account; `POST` create remains unauthenticated
- Paginate the index with `geared_pagination` (JSON array body; `X-Total-Count` and `Link` headers for totals and navigation)
- Render completions via Jbuilder (`index.json.jbuilder` and `_completion.json.jbuilder`)
- Add `prompt_key` on completions (DB default `/default`, not null) and persist it from create when provided


## Test plan
- [x] `pnpm core:test`
- [ ] Manually verify index pagination headers when more than one page of completions exists
- [ ] Manually verify delete returns 404 for another account's completion