### PR TITLE
✨ [core]: Add admin root and admin/stats page

### DIFF
--- a/core/app/controllers/admin/stats_controller.rb
+++ b/core/app/controllers/admin/stats_controller.rb
@@ -2,5 +2,6 @@ class Admin::StatsController < AdminController
   def show
     @accounts_count = Account.count
     @completions_count = Completion.count
+    @completions_by_week = Completion.counts_by_week
   end
 end

--- a/core/app/controllers/admin/stats_controller.rb
+++ b/core/app/controllers/admin/stats_controller.rb
@@ -1,0 +1,6 @@
+class Admin::StatsController < AdminController
+  def show
+    @accounts_count = Account.count
+    @completions_count = Completion.count
+  end
+end

--- a/core/app/models/completion.rb
+++ b/core/app/models/completion.rb
@@ -6,4 +6,15 @@ class Completion < ApplicationRecord
   validates :status, presence: true
 
   scope :ordered, -> { order(created_at: :desc) }
+
+  WEEK_GROUP_SQL = Arel.sql("date(created_at, 'weekday 1', '-7 days')")
+
+  def self.counts_by_week(weeks: 12)
+    grouped = group(WEEK_GROUP_SQL).count
+
+    weeks.times.map do |i|
+      week_start = i.weeks.ago.to_date.beginning_of_week(:monday)
+      { week_start: week_start, count: grouped[week_start.to_s] || 0 }
+    end
+  end
 end

--- a/core/app/views/admin/show.html.erb
+++ b/core/app/views/admin/show.html.erb
@@ -1,6 +1,14 @@
-<h1 class="text-2xl font-bold mb-8"><%= t(".title") %></h1>
+<h1 class="text-2xl font-bold mb-2"><%= t(".title") %></h1>
+<p class="text-sm text-muted mb-8"><%= t(".subtitle") %></p>
 
-<div class="flex flex-col gap-3">
-  <%= link_to t(".stats"), admin_stats_path, class: "p-4 border rounded-xl hover:bg-gray-50" %>
-  <%= link_to t(".jobs"), admin_mission_control_jobs_path, class: "p-4 border rounded-xl hover:bg-gray-50" %>
+<div class="grid grid-cols-2 gap-4">
+  <%= link_to admin_stats_path, class: "p-6 border rounded-xl hover:bg-zinc-50" do %>
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".stats") %></div>
+    <div class="text-sm text-muted"><%= t(".stats_description") %></div>
+  <% end %>
+
+  <%= link_to admin_mission_control_jobs_path, class: "p-6 border rounded-xl hover:bg-zinc-50" do %>
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".jobs") %></div>
+    <div class="text-sm text-muted"><%= t(".jobs_description") %></div>
+  <% end %>
 </div>

--- a/core/app/views/admin/show.html.erb
+++ b/core/app/views/admin/show.html.erb
@@ -1,0 +1,6 @@
+<h1 class="text-2xl font-bold mb-8"><%= t(".title") %></h1>
+
+<div class="flex flex-col gap-3">
+  <%= link_to t(".stats"), admin_stats_path, class: "p-4 border rounded-xl hover:bg-gray-50" %>
+  <%= link_to t(".jobs"), admin_mission_control_jobs_path, class: "p-4 border rounded-xl hover:bg-gray-50" %>
+</div>

--- a/core/app/views/admin/stats/show.html.erb
+++ b/core/app/views/admin/stats/show.html.erb
@@ -1,0 +1,16 @@
+<div class="mb-8">
+  <%= link_to t(".back"), admin_root_path, class: "text-sm text-muted" %>
+</div>
+
+<h1 class="text-2xl font-bold mb-8"><%= t(".title") %></h1>
+
+<div class="grid grid-cols-2 gap-4">
+  <div class="p-6 border rounded-xl">
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".accounts") %></div>
+    <div class="text-3xl font-bold"><%= @accounts_count %></div>
+  </div>
+  <div class="p-6 border rounded-xl">
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".completions") %></div>
+    <div class="text-3xl font-bold"><%= @completions_count %></div>
+  </div>
+</div>

--- a/core/app/views/admin/stats/show.html.erb
+++ b/core/app/views/admin/stats/show.html.erb
@@ -7,11 +7,11 @@
 <div class="grid grid-cols-2 gap-4">
   <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".accounts") %></div>
-    <div class="text-3xl font-bold"><%= @accounts_count %></div>
+    <div class="text-3xl font-bold"><%= number_with_delimiter(@accounts_count) %></div>
   </div>
   <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".completions") %></div>
-    <div class="text-3xl font-bold"><%= @completions_count %></div>
+    <div class="text-3xl font-bold"><%= number_with_delimiter(@completions_count) %></div>
   </div>
 </div>
 
@@ -25,7 +25,7 @@
     <% @completions_by_week.each do |row| %>
       <div class="grid grid-cols-2 gap-4 p-4 border-t">
         <div><%= l(row[:week_start], format: :long) %></div>
-        <div class="text-right font-bold"><%= row[:count] %></div>
+        <div class="text-right font-bold"><%= number_with_delimiter(row[:count]) %></div>
       </div>
     <% end %>
   </div>

--- a/core/app/views/admin/stats/show.html.erb
+++ b/core/app/views/admin/stats/show.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-8">
-  <%= link_to t(".back"), admin_root_path, class: "text-sm text-muted" %>
+  <%= link_to t(".back"), admin_path, class: "text-sm text-muted" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-8"><%= t(".title") %></h1>
@@ -12,5 +12,21 @@
   <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".completions") %></div>
     <div class="text-3xl font-bold"><%= @completions_count %></div>
+  </div>
+</div>
+
+<div class="mt-8">
+  <h2 class="text-xl font-bold mb-4"><%= t(".completions_weekly") %></h2>
+  <div class="border rounded-xl">
+    <div class="grid grid-cols-2 gap-4 p-4 text-xs text-muted uppercase">
+      <div><%= t(".week") %></div>
+      <div class="text-right"><%= t(".count") %></div>
+    </div>
+    <% @completions_by_week.each do |row| %>
+      <div class="grid grid-cols-2 gap-4 p-4 border-t">
+        <div><%= l(row[:week_start], format: :long) %></div>
+        <div class="text-right font-bold"><%= row[:count] %></div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -39,6 +39,18 @@ en:
         prompt_enter_code: "Please enter the authorization code shown on your device:"
         placeholder_code: "ABCD-1234"
         next: "Next"
+  admin:
+    dashboards:
+      show:
+        title: "Admin"
+        stats: "Stats"
+        jobs: "Jobs"
+    stats:
+      show:
+        title: "Stats"
+        back: "Back to admin"
+        accounts: "Accounts"
+        completions: "Completions"
   dashboards:
     show:
       welcome_back: "Welcome back, %{name}"

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -40,17 +40,22 @@ en:
         placeholder_code: "ABCD-1234"
         next: "Next"
   admin:
-    dashboards:
-      show:
-        title: "Admin"
-        stats: "Stats"
-        jobs: "Jobs"
+    show:
+      title: "Admin"
+      subtitle: "Staff tools and observability"
+      stats: "Stats"
+      stats_description: "Accounts, completions, and weekly trends"
+      jobs: "Jobs"
+      jobs_description: "Monitor and manage background work"
     stats:
       show:
         title: "Stats"
         back: "Back to admin"
         accounts: "Accounts"
         completions: "Completions"
+        completions_weekly: "Completions by week"
+        week: "Week"
+        count: "Count"
   dashboards:
     show:
       welcome_back: "Welcome back, %{name}"

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -61,8 +61,8 @@ Rails.application.routes.draw do
   end
 
   # Admin
+  get "admin" => "admin#show", as: :admin
   namespace :admin do
-    root to: "admin#show"
     resource :stats, only: :show
     mount MissionControl::Jobs::Engine, at: "/jobs"
   end

--- a/core/config/routes.rb
+++ b/core/config/routes.rb
@@ -62,6 +62,8 @@ Rails.application.routes.draw do
 
   # Admin
   namespace :admin do
+    root to: "admin#show"
+    resource :stats, only: :show
     mount MissionControl::Jobs::Engine, at: "/jobs"
   end
 

--- a/core/test/controllers/admin_controller_test.rb
+++ b/core/test/controllers/admin_controller_test.rb
@@ -10,7 +10,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "staff can access admin home and stats" do
-    get admin_root_url
+    get admin_url
     assert_response :success
     assert_select "a[href=?]", admin_stats_path
 
@@ -22,7 +22,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   test "non-staff is forbidden" do
     @identity.update!(staff: false)
 
-    get admin_root_url
+    get admin_url
     assert_response :forbidden
   end
 end

--- a/core/test/controllers/admin_controller_test.rb
+++ b/core/test/controllers/admin_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class AdminControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @identity = Identity.create!(email: "admin-test@#{SecureRandom.hex}.com", staff: true)
+    @session = @identity.sessions.create!(user_agent: "TestAgent", ip_address: "127.0.0.1")
+    post session_url, params: { email: @identity.email }
+    magic_link = @identity.magic_links.last
+    post session_magic_link_url, params: { code: magic_link.code }
+  end
+
+  test "staff can access admin home and stats" do
+    get admin_root_url
+    assert_response :success
+    assert_select "a[href=?]", admin_stats_path
+
+    get admin_stats_url
+    assert_response :success
+    assert_match(/\d+/, response.body)
+  end
+
+  test "non-staff is forbidden" do
+    @identity.update!(staff: false)
+
+    get admin_root_url
+    assert_response :forbidden
+  end
+end

--- a/core/test/models/completion_test.rb
+++ b/core/test/models/completion_test.rb
@@ -27,4 +27,31 @@ class CompletionTest < ActiveSupport::TestCase
     assert_not completion.valid?
     assert_includes completion.errors[:input], "can't be blank"
   end
+
+  test "counts_by_week returns completion counts per week" do
+    account = Account.create!(name: "Test Account")
+    this_week = Time.zone.today.noon
+    last_week = 1.week.ago.noon
+
+    Completion.create!(
+      account: account,
+      input: "this week",
+      prompt_key: "/default",
+      status: "success",
+      created_at: this_week
+    )
+    Completion.create!(
+      account: account,
+      input: "last week",
+      prompt_key: "/default",
+      status: "success",
+      created_at: last_week
+    )
+
+    counts = Completion.counts_by_week(weeks: 2)
+
+    assert_equal 2, counts.size
+    assert_equal 1, counts.first[:count]
+    assert_equal 1, counts.second[:count]
+  end
 end


### PR DESCRIPTION
## Summary
- Add admin home and stats routes with a dashboard linking to stats and Mission Control jobs
- Stats page displays account and completion counts for staff users
- Add integration tests for staff access to admin home/stats and forbidden access for non-staff

## Test plan
- [ ] Run `pnpm core:test` (admin controller tests)
- [ ] Sign in as staff and open `/admin` and admin stats; confirm counts render
- [ ] Confirm non-staff users receive forbidden on admin routes


Made with [Cursor](https://cursor.com)