### PR TITLE
✨ Update admin stats view with active users and slash prompts metrics

### DIFF
--- a/core/app/controllers/admin/stats_controller.rb
+++ b/core/app/controllers/admin/stats_controller.rb
@@ -1,7 +1,10 @@
 class Admin::StatsController < AdminController
   def show
     @accounts_count = Account.count
+    @active_users_count = User.active.count
     @completions_count = Completion.count
+    @slash_prompts_count = SlashPrompt.count
+
     @completions_by_week = Completion.counts_by_week
   end
 end

--- a/core/app/views/admin/stats/show.html.erb
+++ b/core/app/views/admin/stats/show.html.erb
@@ -4,14 +4,22 @@
 
 <h1 class="text-2xl font-bold mb-8"><%= t(".title") %></h1>
 
-<div class="grid grid-cols-2 gap-4">
+<div class="grid grid-cols-2 md:grid-cols-4 gap-4">
   <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".accounts") %></div>
     <div class="text-3xl font-bold"><%= number_with_delimiter(@accounts_count) %></div>
   </div>
   <div class="p-6 border rounded-xl">
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".active_users") %></div>
+    <div class="text-3xl font-bold"><%= number_with_delimiter(@active_users_count) %></div>
+  </div>
+  <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".completions") %></div>
     <div class="text-3xl font-bold"><%= number_with_delimiter(@completions_count) %></div>
+  </div>
+  <div class="p-6 border rounded-xl">
+    <div class="text-xs text-muted uppercase mb-2"><%= t(".slash_prompts") %></div>
+    <div class="text-3xl font-bold"><%= number_with_delimiter(@slash_prompts_count) %></div>
   </div>
 </div>
 

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       title: "Admin"
       subtitle: "Staff tools and observability"
       stats: "Stats"
-      stats_description: "Accounts, completions, and weekly trends"
+      stats_description: "Accounts, users, completions, and weekly trends"
       jobs: "Jobs"
       jobs_description: "Monitor and manage background work"
     stats:
@@ -52,7 +52,9 @@ en:
         title: "Stats"
         back: "Back to admin"
         accounts: "Accounts"
+        active_users: "Active Users"
         completions: "Completions"
+        slash_prompts: "Slash Prompts"
         completions_weekly: "Completions by week"
         week: "Week"
         count: "Count"

--- a/core/test/controllers/admin_controller_test.rb
+++ b/core/test/controllers/admin_controller_test.rb
@@ -16,7 +16,10 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
 
     get admin_stats_url
     assert_response :success
-    assert_match(/\d+/, response.body)
+    assert_select "div", text: "Accounts"
+    assert_select "div", text: "Active Users"
+    assert_select "div", text: "Completions"
+    assert_select "div", text: "Slash Prompts"
   end
 
   test "non-staff is forbidden" do


### PR DESCRIPTION
## Summary
- Added `active_users_count` and `slash_prompts_count` to `Admin::StatsController`.
- Updated `admin/stats/show.html.erb` with a responsive 4-column grid for metrics.
- Added new locale keys and updated the stats description in `en.yml`.
- Added test assertions to verify the presence of new metrics.

## Test plan
- [x] Ran `bundle exec rails test test/controllers/admin_controller_test.rb` successfully.