### PR TITLE
📊 Update admin stats view with personal accounts and simple links

### DIFF
--- a/core/app/controllers/admin/stats_controller.rb
+++ b/core/app/controllers/admin/stats_controller.rb
@@ -3,11 +3,17 @@ class Admin::StatsController < AdminController
     @accounts_count = Account.count
     @completions_count = Completion.count
 
-    @personal_accounts = Account.where(personal: true).map do |account|
+    beginning_of_day = Time.current.beginning_of_day
+    accounts = Account.where(personal: true)
+
+    total_counts = Completion.where(account_id: accounts.ids).group(:account_id).count
+    today_counts = Completion.where(account_id: accounts.ids).where("created_at >= ?", beginning_of_day).group(:account_id).count
+
+    @personal_accounts = accounts.map do |account|
       {
         name: account.name,
-        total_completions: account.completions.count,
-        today_completions: account.completions.where("created_at >= ?", Time.current.beginning_of_day).count
+        total_completions: total_counts[account.id] || 0,
+        today_completions: today_counts[account.id] || 0
       }
     end.sort_by { |a| -a[:total_completions] }
   end

--- a/core/app/controllers/admin/stats_controller.rb
+++ b/core/app/controllers/admin/stats_controller.rb
@@ -2,6 +2,13 @@ class Admin::StatsController < AdminController
   def show
     @accounts_count = Account.count
     @completions_count = Completion.count
-    @completions_by_week = Completion.counts_by_week
+
+    @personal_accounts = Account.where(personal: true).map do |account|
+      {
+        name: account.name,
+        total_completions: account.completions.count,
+        today_completions: account.completions.where("created_at >= ?", Time.current.beginning_of_day).count
+      }
+    end.sort_by { |a| -a[:total_completions] }
   end
 end

--- a/core/app/views/admin/show.html.erb
+++ b/core/app/views/admin/show.html.erb
@@ -1,14 +1,7 @@
 <h1 class="text-2xl font-bold mb-2"><%= t(".title") %></h1>
 <p class="text-sm text-muted mb-8"><%= t(".subtitle") %></p>
 
-<div class="grid grid-cols-2 gap-4">
-  <%= link_to admin_stats_path, class: "p-6 border rounded-xl hover:bg-zinc-50" do %>
-    <div class="text-xs text-muted uppercase mb-2"><%= t(".stats") %></div>
-    <div class="text-sm text-muted"><%= t(".stats_description") %></div>
-  <% end %>
-
-  <%= link_to admin_mission_control_jobs_path, class: "p-6 border rounded-xl hover:bg-zinc-50" do %>
-    <div class="text-xs text-muted uppercase mb-2"><%= t(".jobs") %></div>
-    <div class="text-sm text-muted"><%= t(".jobs_description") %></div>
-  <% end %>
+<div class="flex gap-4 text-sm">
+  <%= link_to t(".stats"), admin_stats_path, class: "text-muted hover:text-zinc-900 underline underline-offset-4" %>
+  <%= link_to t(".jobs"), admin_mission_control_jobs_path, class: "text-muted hover:text-zinc-900 underline underline-offset-4" %>
 </div>

--- a/core/app/views/admin/stats/show.html.erb
+++ b/core/app/views/admin/stats/show.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="text-2xl font-bold mb-8"><%= t(".title") %></h1>
 
-<div class="grid grid-cols-2 gap-4">
+<div class="grid grid-cols-2 gap-4 mb-8">
   <div class="p-6 border rounded-xl">
     <div class="text-xs text-muted uppercase mb-2"><%= t(".accounts") %></div>
     <div class="text-3xl font-bold"><%= number_with_delimiter(@accounts_count) %></div>
@@ -16,16 +16,18 @@
 </div>
 
 <div class="mt-8">
-  <h2 class="text-xl font-bold mb-4"><%= t(".completions_weekly") %></h2>
+  <h2 class="text-xl font-bold mb-4"><%= t(".personal_accounts") %></h2>
   <div class="border rounded-xl">
-    <div class="grid grid-cols-2 gap-4 p-4 text-xs text-muted uppercase">
-      <div><%= t(".week") %></div>
-      <div class="text-right"><%= t(".count") %></div>
+    <div class="grid grid-cols-3 gap-4 p-4 text-xs text-muted uppercase">
+      <div><%= t(".account") %></div>
+      <div class="text-right"><%= t(".total") %></div>
+      <div class="text-right"><%= t(".today") %></div>
     </div>
-    <% @completions_by_week.each do |row| %>
-      <div class="grid grid-cols-2 gap-4 p-4 border-t">
-        <div><%= l(row[:week_start], format: :long) %></div>
-        <div class="text-right font-bold"><%= number_with_delimiter(row[:count]) %></div>
+    <% @personal_accounts.each do |account| %>
+      <div class="grid grid-cols-3 gap-4 p-4 border-t">
+        <div class="font-medium"><%= account[:name] %></div>
+        <div class="text-right"><%= number_with_delimiter(account[:total_completions]) %></div>
+        <div class="text-right"><%= number_with_delimiter(account[:today_completions]) %></div>
       </div>
     <% end %>
   </div>

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -53,9 +53,10 @@ en:
         back: "Back to admin"
         accounts: "Accounts"
         completions: "Completions"
-        completions_weekly: "Completions by week"
-        week: "Week"
-        count: "Count"
+        personal_accounts: "Personal Accounts"
+        account: "Account"
+        total: "Total"
+        today: "Today"
   dashboards:
     show:
       welcome_back: "Welcome back, %{name}"


### PR DESCRIPTION
## Summary
- Simplified the admin home page to use simple text links for 'Stats' and 'Jobs'.
- Updated the stats view to include a list of personal accounts with their total and today's completion counts.
- Removed the weekly completion trends table.
- Updated `Admin::StatsController` and locales accordingly.

## Test plan
- [x] Ran `bin/rails test test/controllers/admin_controller_test.rb` successfully.
- [x] All 83 core tests passed.