### PR TITLE
✨ [desktop,core]: Add hostname to User-Agent for device identification

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.52.0", features = ["time"] }
 tauri-plugin-log = "2"
 tauri-plugin-http = "2"
 log = "0.4"
+hostname = "0.4"
 
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -54,7 +54,18 @@ fn get_system_info(app: tauri::AppHandle) -> SystemInfo {
 #[tauri::command]
 fn get_hostname() -> String {
     hostname::get()
-        .map(|h| h.to_string_lossy().to_string())
+        .map(|h| {
+            let sanitized: String = h
+                .to_string_lossy()
+                .chars()
+                .filter(|c| c.is_ascii() && !c.is_control())
+                .collect();
+            if sanitized.is_empty() {
+                "Unknown".to_string()
+            } else {
+                sanitized
+            }
+        })
         .unwrap_or_else(|_| "Unknown".to_string())
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -58,7 +58,7 @@ fn get_hostname() -> String {
             let sanitized: String = h
                 .to_string_lossy()
                 .chars()
-                .filter(|c| c.is_ascii() && !c.is_control())
+                .filter(|c| c.is_ascii() && !c.is_control() && *c != '(' && *c != ')')
                 .collect();
             if sanitized.is_empty() {
                 "Unknown".to_string()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -52,6 +52,13 @@ fn get_system_info(app: tauri::AppHandle) -> SystemInfo {
 }
 
 #[tauri::command]
+fn get_hostname() -> String {
+    hostname::get()
+        .map(|h| h.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "Unknown".to_string())
+}
+
+#[tauri::command]
 async fn get_selected_text() -> Result<String, String> {
     let text = get_selected_text::get_selected_text().map_err(|e| e.to_string())?;
     Ok(text)
@@ -233,6 +240,7 @@ pub fn run() {
             autostart::is_autostart_enabled,
             autostart::set_autostart,
             get_system_info,
+            get_hostname,
             get_selected_text,
             set_pending_selection_input,
             open_log_folder,

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -15,13 +15,16 @@ function getUserAgent(): Promise<string> {
 
   userAgentPromise = (async () => {
     try {
-      const { os, version } = await invoke<{ os: string, version: string }>('get_system_info')
+      const [{ os, version }, hostname] = await Promise.all([
+        invoke<{ os: string, version: string }>('get_system_info'),
+        invoke<string>('get_hostname'),
+      ])
       const platform = {
         macos: 'macOS',
         windows: 'Windows',
         linux: 'Linux',
       }[os] || os
-      return `Typo Desktop/${version} (${platform})`
+      return `Typo Desktop/${version} (${platform}) ${hostname}`
     }
     catch (error) {
       console.error('failed to get system info for user agent', error)

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -27,7 +27,7 @@ function getUserAgent(): Promise<string> {
         windows: 'Windows',
         linux: 'Linux',
       }[os] || os
-      return `Typo Desktop/${version} (${platform}) ${hostname}`
+      return `Typo Desktop/${version} (${platform}; ${hostname})`
     }
     catch (error) {
       console.error('failed to get system info for user agent', error)

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -17,7 +17,10 @@ function getUserAgent(): Promise<string> {
     try {
       const [{ os, version }, hostname] = await Promise.all([
         invoke<{ os: string, version: string }>('get_system_info'),
-        invoke<string>('get_hostname'),
+        invoke<string>('get_hostname').catch((error) => {
+          console.error('failed to get hostname', error)
+          return 'Unknown'
+        }),
       ])
       const platform = {
         macos: 'macOS',

--- a/core/app/models/session.rb
+++ b/core/app/models/session.rb
@@ -28,8 +28,11 @@ class Session < ApplicationRecord
     hostname = user_agent[/Typo Desktop\/[^\s]+ \([^)]+\)\s+(.+)/, 1]&.strip
 
     parts = []
-    parts << client if client
-    parts << "on #{os}" if os
+    if client && os
+      parts << "#{client} on #{os}"
+    elsif client || os
+      parts << (client || os)
+    end
     parts << "(#{hostname})" if hostname.present?
 
     parts.presence&.join(" ") || user_agent.truncate(35)

--- a/core/app/models/session.rb
+++ b/core/app/models/session.rb
@@ -25,7 +25,7 @@ class Session < ApplicationRecord
     when /Safari/i then "Safari"
     end
 
-    hostname = user_agent[/Typo Desktop\/[^\s]+ \([^)]+\)\s+(.+)/, 1]&.strip
+    hostname = user_agent[/Typo Desktop\/[^\s]+ \([^;)]+;\s*([^)]+)\)/, 1]&.strip
 
     parts = []
     if client && os
@@ -33,7 +33,7 @@ class Session < ApplicationRecord
     elsif client || os
       parts << (client || os)
     end
-    parts << "(#{hostname})" if hostname.present?
+    parts << "(#{hostname})" if hostname.present? && hostname != "Unknown"
 
     parts.presence&.join(" ") || user_agent.truncate(35)
   end

--- a/core/app/models/session.rb
+++ b/core/app/models/session.rb
@@ -25,13 +25,14 @@ class Session < ApplicationRecord
     when /Safari/i then "Safari"
     end
 
-    if client && os
-      "#{client} on #{os}"
-    elsif client || os
-      client || os
-    else
-      user_agent.truncate(35)
-    end
+    hostname = user_agent[/Typo Desktop\/[^\s]+ \([^)]+\)\s+(.+)/, 1]&.strip
+
+    parts = []
+    parts << client if client
+    parts << "on #{os}" if os
+    parts << "(#{hostname})" if hostname.present?
+
+    parts.presence&.join(" ") || user_agent.truncate(35)
   end
 
   def desktop_version

--- a/core/test/models/session_test.rb
+++ b/core/test/models/session_test.rb
@@ -7,7 +7,7 @@ class SessionTest < ActiveSupport::TestCase
   end
 
   test "user_agent_summary correctly identifies macOS desktop app with hostname" do
-    session = Session.new(user_agent: "Typo Desktop/0.1.0 (macOS) MacBook-Pro")
+    session = Session.new(user_agent: "Typo Desktop/0.1.0 (macOS; MacBook-Pro)")
     assert_equal "Typo Client on macOS (MacBook-Pro)", session.user_agent_summary
   end
 

--- a/core/test/models/session_test.rb
+++ b/core/test/models/session_test.rb
@@ -6,6 +6,11 @@ class SessionTest < ActiveSupport::TestCase
     assert_equal "Typo Client on macOS", session.user_agent_summary
   end
 
+  test "user_agent_summary correctly identifies macOS desktop app with hostname" do
+    session = Session.new(user_agent: "Typo Desktop/0.1.0 (macOS) MacBook-Pro")
+    assert_equal "Typo Client on macOS (MacBook-Pro)", session.user_agent_summary
+  end
+
   test "desktop_version returns correct desktop version tag" do
     session = Session.new(kind: :desktop, user_agent: "Typo Desktop/0.1.0 (macOS)")
     assert_equal "v0.1.0", session.desktop_version


### PR DESCRIPTION
## Summary
- Add `hostname` crate to Rust backend and expose `get_hostname` Tauri command
- Include system hostname in User-Agent header for device identification during authorization
- Update Session model to parse and display hostname in session summaries

## Test plan
- [x] Session model tests pass with new hostname parsing
- [ ] Verify hostname appears in User-Agent on macOS/Windows/Linux
- [ ] Verify device authorization page shows device name