### PR TITLE
♻️ [desktop]: Add indicator shell with animated processing border

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,6 +78,32 @@ fn pending_selection_payload() -> &'static Mutex<Option<SetInputPayload>> {
     PENDING_SELECTION_PAYLOAD.get_or_init(|| Mutex::new(None))
 }
 
+fn pending_open_settings() -> &'static Mutex<bool> {
+    static PENDING_OPEN_SETTINGS: OnceLock<Mutex<bool>> = OnceLock::new();
+    PENDING_OPEN_SETTINGS.get_or_init(|| Mutex::new(false))
+}
+
+pub(crate) fn set_pending_open_settings(value: bool) {
+    if let Ok(mut pending) = pending_open_settings().lock() {
+        *pending = value;
+    }
+}
+
+#[tauri::command]
+fn consume_pending_open_settings() -> bool {
+    match pending_open_settings().lock() {
+        Ok(mut pending) => {
+            let value = *pending;
+            *pending = false;
+            value
+        }
+        Err(error) => {
+            log::error!("failed to access pending open-settings flag: {}", error);
+            false
+        }
+    }
+}
+
 fn app_cli_selection_trigger(app: &tauri::AppHandle) {
     log::debug!("app_cli_selection_trigger");
 
@@ -239,6 +265,7 @@ pub fn run() {
             keyboard::keyboard_select_all,
             keyboard::keyboard_paste_text,
             consume_pending_selection_input,
+            consume_pending_open_settings,
             tray::update_tray_menu,
             windows::open_upgrade_window,
             windows::open_indicator_window,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -242,6 +242,7 @@ pub fn run() {
             tray::update_tray_menu,
             windows::open_upgrade_window,
             windows::open_indicator_window,
+            windows::open_main_window,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,33 +78,6 @@ fn pending_selection_payload() -> &'static Mutex<Option<SetInputPayload>> {
     PENDING_SELECTION_PAYLOAD.get_or_init(|| Mutex::new(None))
 }
 
-fn pending_open_settings() -> &'static Mutex<bool> {
-    static PENDING_OPEN_SETTINGS: OnceLock<Mutex<bool>> = OnceLock::new();
-    PENDING_OPEN_SETTINGS.get_or_init(|| Mutex::new(false))
-}
-
-pub(crate) fn set_pending_open_settings(value: bool) {
-    match pending_open_settings().lock() {
-        Ok(mut pending) => *pending = value,
-        Err(error) => log::error!("failed to lock pending open-settings flag: {}", error),
-    }
-}
-
-#[tauri::command]
-fn consume_pending_open_settings() -> bool {
-    match pending_open_settings().lock() {
-        Ok(mut pending) => {
-            let value = *pending;
-            *pending = false;
-            value
-        }
-        Err(error) => {
-            log::error!("failed to access pending open-settings flag: {}", error);
-            false
-        }
-    }
-}
-
 fn app_cli_selection_trigger(app: &tauri::AppHandle) {
     log::debug!("app_cli_selection_trigger");
 
@@ -266,7 +239,7 @@ pub fn run() {
             keyboard::keyboard_select_all,
             keyboard::keyboard_paste_text,
             consume_pending_selection_input,
-            consume_pending_open_settings,
+            windows::consume_pending_open_settings,
             tray::update_tray_menu,
             windows::open_upgrade_window,
             windows::open_indicator_window,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -84,8 +84,9 @@ fn pending_open_settings() -> &'static Mutex<bool> {
 }
 
 pub(crate) fn set_pending_open_settings(value: bool) {
-    if let Ok(mut pending) = pending_open_settings().lock() {
-        *pending = value;
+    match pending_open_settings().lock() {
+        Ok(mut pending) => *pending = value,
+        Err(error) => log::error!("failed to lock pending open-settings flag: {}", error),
     }
 }
 

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -155,10 +155,7 @@ fn handle_tray_icon_event(app: &AppHandle, event: TrayIconEvent) {
 fn handle_menu_event(app: &AppHandle, id: &str) {
     match id {
         ID_SHOW => crate::windows::show_and_focus_main(app),
-        ID_SETTINGS => {
-            crate::windows::show_and_focus_main(app);
-            let _ = app.emit("open-settings", ());
-        }
+        ID_SETTINGS => crate::windows::show_and_focus_main_settings(app),
         ID_PIN_INDICATOR => toggle_pin_indicator_action(app),
         ID_CHECK_UPDATES => {
             crate::windows::create_upgrade_window(app);

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -148,15 +148,15 @@ fn handle_tray_icon_event(app: &AppHandle, event: TrayIconEvent) {
         if let Err(err) = app.emit(EV_TOGGLE_CLICKED, ()) {
             log::error!("failed to emit {}: {}", EV_TOGGLE_CLICKED, err);
         }
-        show_and_focus_main(app);
+        crate::windows::show_and_focus_main(app);
     }
 }
 
 fn handle_menu_event(app: &AppHandle, id: &str) {
     match id {
-        ID_SHOW => show_and_focus_main(app),
+        ID_SHOW => crate::windows::show_and_focus_main(app),
         ID_SETTINGS => {
-            show_and_focus_main(app);
+            crate::windows::show_and_focus_main(app);
             let _ = app.emit("open-settings", ());
         }
         ID_PIN_INDICATOR => toggle_pin_indicator_action(app),
@@ -218,20 +218,6 @@ fn toggle_autostart_action(app: &AppHandle) {
 fn open_log_folder_action(app: &AppHandle) {
     if let Err(err) = crate::open_log_folder_inner(app) {
         log::error!("{}", err);
-    }
-}
-
-fn show_and_focus_main(app: &AppHandle) {
-    crate::windows::create_main_window(app);
-    let Some(window) = app.get_webview_window("main") else {
-        return;
-    };
-
-    if let Err(err) = window.show() {
-        log::error!("failed to show main window: {}", err);
-    }
-    if let Err(err) = window.set_focus() {
-        log::error!("failed to focus main window: {}", err);
     }
 }
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1,9 +1,20 @@
 // apps/desktop/src-tauri/src/windows.rs
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "macos")]
 use tauri::{LogicalPosition, TitleBarStyle};
 
+static PENDING_OPEN_SETTINGS: AtomicBool = AtomicBool::new(false);
+
+pub fn set_pending_open_settings(value: bool) {
+    PENDING_OPEN_SETTINGS.store(value, Ordering::Relaxed);
+}
+
+#[tauri::command]
+pub fn consume_pending_open_settings() -> bool {
+    PENDING_OPEN_SETTINGS.swap(false, Ordering::Relaxed)
+}
 
 #[tauri::command]
 pub fn open_upgrade_window(app: AppHandle) {
@@ -22,7 +33,7 @@ pub fn open_main_window(app: AppHandle) {
 
 pub fn show_and_focus_main_settings(app: &AppHandle) {
     if app.get_webview_window("main").is_none() {
-        crate::set_pending_open_settings(true);
+        set_pending_open_settings(true);
     }
     show_and_focus_main(app);
     if let Err(err) = app.emit("open-settings", ()) {

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -21,15 +21,10 @@ pub fn open_main_window(app: AppHandle) {
 }
 
 pub fn show_and_focus_main_settings(app: &AppHandle) {
-    let had_main_window = app.get_webview_window("main").is_some();
-    if !had_main_window {
-        crate::set_pending_open_settings(true);
-    }
+    crate::set_pending_open_settings(true);
     show_and_focus_main(app);
-    if had_main_window {
-        if let Err(err) = app.emit("open-settings", ()) {
-            log::error!("failed to emit open-settings: {}", err);
-        }
+    if let Err(err) = app.emit("open-settings", ()) {
+        log::error!("failed to emit open-settings: {}", err);
     }
 }
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1,5 +1,5 @@
 // apps/desktop/src-tauri/src/windows.rs
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 
 #[cfg(target_os = "macos")]
 use tauri::{LogicalPosition, TitleBarStyle};
@@ -71,9 +71,23 @@ pub fn create_main_window(app: &AppHandle) {
         .skip_taskbar(false)
         .visible(true);
 
-    if let Err(e) = win_builder.build() {
-        log::error!("failed to build main window: {}", e);
-    }
+    let window = match win_builder.build() {
+        Ok(window) => window,
+        Err(e) => {
+            log::error!("failed to build main window: {}", e);
+            return;
+        }
+    };
+
+    let window_for_close = window.clone();
+    window.on_window_event(move |event| {
+        if let WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_close();
+            if let Err(err) = window_for_close.hide() {
+                log::error!("failed to hide main window: {}", err);
+            }
+        }
+    });
 }
 
 pub fn create_indicator_window(app: &AppHandle, show: bool) {

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -21,9 +21,15 @@ pub fn open_main_window(app: AppHandle) {
 }
 
 pub fn show_and_focus_main_settings(app: &AppHandle) {
+    let had_main_window = app.get_webview_window("main").is_some();
+    if !had_main_window {
+        crate::set_pending_open_settings(true);
+    }
     show_and_focus_main(app);
-    if let Err(err) = app.emit("open-settings", ()) {
-        log::error!("failed to emit open-settings: {}", err);
+    if had_main_window {
+        if let Err(err) = app.emit("open-settings", ()) {
+            log::error!("failed to emit open-settings: {}", err);
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -21,7 +21,9 @@ pub fn open_main_window(app: AppHandle) {
 }
 
 pub fn show_and_focus_main_settings(app: &AppHandle) {
-    crate::set_pending_open_settings(true);
+    if app.get_webview_window("main").is_none() {
+        crate::set_pending_open_settings(true);
+    }
     show_and_focus_main(app);
     if let Err(err) = app.emit("open-settings", ()) {
         log::error!("failed to emit open-settings: {}", err);

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -70,7 +70,7 @@ pub fn create_indicator_window(app: &AppHandle, show: bool) {
     };
 
     let win_width = 360.0;
-    let win_height = 56.0;
+    let win_height = 60.0;
     let x = (width - win_width) / 2.0;
     let y = height - win_height - 20.0; // 20px above the bottom of the work area
 

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -15,6 +15,25 @@ pub fn open_indicator_window(app: AppHandle) {
     create_indicator_window(&app, true);
 }
 
+#[tauri::command]
+pub fn open_main_window(app: AppHandle) {
+    show_and_focus_main(&app);
+}
+
+pub fn show_and_focus_main(app: &AppHandle) {
+    create_main_window(app);
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+
+    if let Err(err) = window.show() {
+        log::error!("failed to show main window: {}", err);
+    }
+    if let Err(err) = window.set_focus() {
+        log::error!("failed to focus main window: {}", err);
+    }
+}
+
 pub fn create_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.set_focus();

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -32,9 +32,7 @@ pub fn open_main_window(app: AppHandle) {
 }
 
 pub fn show_and_focus_main_settings(app: &AppHandle) {
-    if app.get_webview_window("main").is_none() {
-        set_pending_open_settings(true);
-    }
+    set_pending_open_settings(true);
     show_and_focus_main(app);
     if let Err(err) = app.emit("open-settings", ()) {
         log::error!("failed to emit open-settings: {}", err);

--- a/apps/desktop/src-tauri/src/windows.rs
+++ b/apps/desktop/src-tauri/src/windows.rs
@@ -1,5 +1,5 @@
 // apps/desktop/src-tauri/src/windows.rs
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 #[cfg(target_os = "macos")]
 use tauri::{LogicalPosition, TitleBarStyle};
@@ -17,7 +17,14 @@ pub fn open_indicator_window(app: AppHandle) {
 
 #[tauri::command]
 pub fn open_main_window(app: AppHandle) {
-    show_and_focus_main(&app);
+    show_and_focus_main_settings(&app);
+}
+
+pub fn show_and_focus_main_settings(app: &AppHandle) {
+    show_and_focus_main(app);
+    if let Err(err) = app.emit("open-settings", ()) {
+        log::error!("failed to emit open-settings: {}", err);
+    }
 }
 
 pub fn show_and_focus_main(app: &AppHandle) {

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -488,7 +488,8 @@ async function handleErrorClick() {
 
         <p
           v-else-if="state === 'error'"
-          class="truncate text-sm text-red-400 px-2 font-medium cursor-pointer hover:underline"
+          class="truncate text-sm text-red-400 px-2 font-medium"
+          :class="{ 'cursor-pointer hover:underline': isRateLimited }"
           :data-tauri-drag-region="isRateLimited ? undefined : true"
           @mousedown="isRateLimited ? $event.stopPropagation() : undefined"
           @click="handleErrorClick"

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -495,6 +495,7 @@ function gotoSettings() {
     </div>
   </div>
 </template>
+
 <style scoped>
 :global(body) {
   background-color: transparent;

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -260,29 +260,14 @@ async function fetchCorrection(text: string, preResolved?: { text: string, promp
   const signal = abortController.signal
 
   // Note: only for development
-  // handle `/mock` prefix
-  const mockPrefixMatch = text.match(/^\s*\/mock\b/)
-  if (import.meta.env.DEV && mockPrefixMatch) {
-    const mockPayload = text.slice(mockPrefixMatch[0].length).trim()
-    await new Promise<void>((resolve, reject) => {
-      if (signal.aborted) {
-        reject(new DOMException('Aborted', 'AbortError'))
-        return
-      }
-      let timeout: ReturnType<typeof setTimeout>
-      const onAbort = () => {
-        clearTimeout(timeout)
-        signal.removeEventListener('abort', onAbort)
-        reject(new DOMException('Aborted', 'AbortError'))
-      }
-      timeout = setTimeout(() => {
-        signal.removeEventListener('abort', onAbort)
-        resolve()
-      }, 5000)
-      signal.addEventListener('abort', onAbort)
+  if (import.meta.env.DEV && text.trim().startsWith('/mock')) {
+    await new Promise((resolve, reject) => {
+      const t = setTimeout(resolve, 5000)
+      signal.addEventListener('abort', () => { clearTimeout(t); reject(new DOMException('Aborted', 'AbortError')) }, { once: true })
     })
-    return mockPayload || 'Mock Result'
+    return text.replace(/^\s*\/mock/, '').trim() || 'Mock Result'
   }
+
   const aiProvider = await store.get('ai_provider')
   let process: (text: string, abortSignal?: AbortSignal, preResolved?: { text: string, prompt: string, command?: string }) => Promise<string>
   switch (aiProvider) {

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -43,7 +43,7 @@ const INDICATOR_MIN_IDLE_WIDTH = 180
 const INDICATOR_MAX_ACTIVE_WIDTH = 520
 const INDICATOR_MAX_CONTENT_WIDTH = 390
 const INDICATOR_CHROME_WIDTH = 106
-const INDICATOR_HEIGHT = 56
+const INDICATOR_HEIGHT = 60
 
 let unlistenSetInput: UnlistenFn
 let unlistenShortcutRequests: (() => void) | undefined
@@ -256,6 +256,12 @@ onUnmounted(() => {
 let abortController: AbortController | null = null
 
 async function fetchCorrection(text: string, preResolved?: { text: string, prompt: string, command?: string }): Promise<string> {
+  const mockMatch = text.match(/^\s*\/mock(?:\s+([\s\S]*))?$/)
+  if (import.meta.env.DEV && mockMatch) {
+    await sleep(5000)
+    return `${text.trim()}`
+  }
+
   abortController = new AbortController()
   const aiProvider = await store.get('ai_provider')
   let process: (text: string, abortSignal?: AbortSignal, preResolved?: { text: string, prompt: string, command?: string }) => Promise<string>
@@ -421,61 +427,73 @@ function gotoSettings() {
 
 <template>
   <div
-    class="indicator-capsule h-full w-full flex items-center pl-4 gap-3 transition-shadow duration-300 select-none bg-neutral-800 rounded-lg border border-white/10 overflow-hidden cursor-grab active:cursor-grabbing"
-    :class="{ 'indicator-capsule--processing': state === 'processing' }"
+    class="indicator-shell h-full w-full p-0.5"
+    :class="{ 'indicator-shell--processing': state === 'processing' }"
     tabindex="0"
     data-tauri-drag-region
     @keydown.esc="onESC"
   >
-    <AppLogo version dark drag class="size-7" />
-
-    <!-- Center: Status -->
-    <div class="indicator-content flex overflow-hidden min-w-0 h-full items-center" data-tauri-drag-region>
-      <div v-if="state === 'processing'" class="flex max-w-full items-center gap-2 px-2 overflow-hidden" data-tauri-drag-region>
-        <div v-if="commandName" class="flex items-center gap-1 shrink-0 bg-blue-500/10 pl-1 pr-1.5 py-0.5 rounded border border-blue-500/20" data-tauri-drag-region>
-          <TerminalIcon class="w-3 h-3 text-blue-400" data-tauri-drag-region />
-          <span class="text-[10px] font-bold text-blue-400 tracking-tight uppercase" data-tauri-drag-region>
-            {{ commandName.startsWith('/') ? commandName.slice(1) : commandName }}
-          </span>
-        </div>
-        <Loader2Icon class="w-3.5 h-3.5 animate-spin text-blue-400 shrink-0" data-tauri-drag-region />
-        <span class="truncate text-sm text-blue-100/90 shrink min-w-0 font-medium" data-tauri-drag-region>{{ inputText }}</span>
-        <span class="text-[10px] text-blue-400/40 font-mono shrink-0" data-tauri-drag-region>{{ inputText?.length }}</span>
-      </div>
-
-      <div v-else-if="state === 'result'" class="flex items-center gap-2 px-2 overflow-hidden" data-tauri-drag-region>
-        <span class="truncate text-sm text-green-400 font-medium" data-tauri-drag-region>{{ resultText }}</span>
-        <template v-if="copyResult">
-          <ClipboardCheckIcon class="w-4 h-4 text-green-400 shrink-0" data-tauri-drag-region />
-          <span class="text-[10px] text-green-400/50 font-mono shrink-0" data-tauri-drag-region>{{ t('main.status.copied') }}</span>
-        </template>
-      </div>
-
-      <p
-        v-else-if="state === 'error'"
-        class="truncate text-sm text-red-400 px-2 font-medium cursor-pointer hover:underline"
-        :data-tauri-drag-region="isRateLimited ? false : true"
-        @click="isRateLimited ? (login(), hideIndicator()) : null"
-      >
-        {{ errorText }}
-      </p>
-
-      <kbd v-else class="px-1.5 py-0.5 rounded border border-white/10 bg-white/5 font-mono text-[10px] text-white/40" data-tauri-drag-region>
-        {{ formatShortcut(globalShortcut, isMacOS) }}
-      </kbd>
-    </div>
-
-    <!-- Right: Settings -->
-    <button
-      class="size-7 shrink-0 flex items-center justify-center rounded-lg hover:bg-white/5 transition-colors cursor-pointer"
-      @click="gotoSettings"
+    <div
+      class="indicator-capsule h-full w-full flex items-center pl-4 gap-3 transition-shadow duration-300 select-none bg-neutral-800 rounded-lg border border-white/10 overflow-hidden cursor-grab active:cursor-grabbing"
+      data-tauri-drag-region
     >
-      <SettingsIcon class="w-4 h-4 text-white/40 hover:text-white/60" />
-    </button>
+      <AppLogo version dark drag class="size-7" />
+
+      <!-- Center: Status -->
+      <div class="indicator-content flex overflow-hidden min-w-0 h-full items-center" data-tauri-drag-region>
+        <div v-if="state === 'processing'" class="flex max-w-full items-center gap-2 px-2 overflow-hidden" data-tauri-drag-region>
+          <div v-if="commandName" class="flex items-center gap-1 shrink-0 bg-blue-500/10 pl-1 pr-1.5 py-0.5 rounded border border-blue-500/20" data-tauri-drag-region>
+            <TerminalIcon class="w-3 h-3 text-blue-400" data-tauri-drag-region />
+            <span class="text-[10px] font-bold text-blue-400 tracking-tight uppercase" data-tauri-drag-region>
+              {{ commandName.startsWith('/') ? commandName.slice(1) : commandName }}
+            </span>
+          </div>
+          <Loader2Icon class="w-3.5 h-3.5 animate-spin text-blue-400 shrink-0" data-tauri-drag-region />
+          <span class="truncate text-sm text-blue-100/90 shrink min-w-0 font-medium" data-tauri-drag-region>{{ inputText }}</span>
+          <span class="text-[10px] text-blue-400/40 font-mono shrink-0" data-tauri-drag-region>{{ inputText?.length }}</span>
+        </div>
+
+        <div v-else-if="state === 'result'" class="flex items-center gap-2 px-2 overflow-hidden" data-tauri-drag-region>
+          <span class="truncate text-sm text-green-400 font-medium" data-tauri-drag-region>{{ resultText }}</span>
+          <template v-if="copyResult">
+            <ClipboardCheckIcon class="w-4 h-4 text-green-400 shrink-0" data-tauri-drag-region />
+            <span class="text-[10px] text-green-400/50 font-mono shrink-0" data-tauri-drag-region>{{ t('main.status.copied') }}</span>
+          </template>
+        </div>
+
+        <p
+          v-else-if="state === 'error'"
+          class="truncate text-sm text-red-400 px-2 font-medium cursor-pointer hover:underline"
+          :data-tauri-drag-region="isRateLimited ? false : true"
+          @click="isRateLimited ? (login(), hideIndicator()) : null"
+        >
+          {{ errorText }}
+        </p>
+
+        <kbd v-else class="px-1.5 py-0.5 rounded border border-white/10 bg-white/5 font-mono text-[10px] text-white/40" data-tauri-drag-region>
+          {{ formatShortcut(globalShortcut, isMacOS) }}
+        </kbd>
+      </div>
+
+      <!-- Right: Settings -->
+      <button
+        class="size-7 shrink-0 flex items-center justify-center rounded-lg hover:bg-white/5 transition-colors cursor-pointer"
+        @click="gotoSettings"
+      >
+        <SettingsIcon class="w-4 h-4 text-white/40 hover:text-white/60" />
+      </button>
+    </div>
   </div>
 </template>
 
 <style scoped>
+body, .indicator-shell {
+  position: relative;
+  border-radius: 0.625rem;
+  background-color: transparent;
+  overflow: hidden;
+}
+
 .indicator-capsule {
   position: relative;
   box-shadow: 0 10px 30px rgb(0 0 0 / 24%);
@@ -485,17 +503,24 @@ function gotoSettings() {
   max-width: 390px;
 }
 
-.indicator-capsule--processing {
-  border-color: rgb(229 229 229 / 18%);
-}
-
-.indicator-capsule--processing::before {
+.indicator-shell--processing::after {
   position: absolute;
   inset: 0;
-  padding: 1px;
   content: "";
   pointer-events: none;
   border-radius: inherit;
+  z-index: 0;
+  background-color: rgb(38 38 38);
+}
+
+.indicator-shell--processing::before {
+  position: absolute;
+  inset: 0;
+  padding: 2px;
+  content: "";
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 1;
   background:
     conic-gradient(
       from var(--indicator-runner-angle, 0deg),
@@ -516,6 +541,10 @@ function gotoSettings() {
     linear-gradient(#000 0 0);
   mask-composite: exclude;
   animation: indicator-border-runner 3.6s linear infinite;
+}
+
+.indicator-shell--processing .indicator-capsule {
+  z-index: 1;
 }
 
 @property --indicator-runner-angle {

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -258,20 +258,22 @@ let abortController: AbortController | null = null
 async function fetchCorrection(text: string, preResolved?: { text: string, prompt: string, command?: string }): Promise<string> {
   abortController = new AbortController()
 
-  const mockMatch = text.match(/^\s*\/mock(?:\s+([\s\S]*))?$/)
-  if (import.meta.env.DEV && mockMatch) {
+  const mockPrefixMatch = text.match(/^\s*\/mock\b/)
+  if (import.meta.env.DEV && mockPrefixMatch) {
+    const mockPayload = text.slice(mockPrefixMatch[0].length).trim()
     await new Promise<void>((resolve, reject) => {
+      let timeout: ReturnType<typeof setTimeout>
       const onAbort = () => {
         clearTimeout(timeout)
         reject(new DOMException('Aborted', 'AbortError'))
       }
-      const timeout = setTimeout(() => {
+      timeout = setTimeout(() => {
         abortController?.signal.removeEventListener('abort', onAbort)
         resolve()
       }, 5000)
       abortController?.signal.addEventListener('abort', onAbort)
     })
-    return mockMatch[1]?.trim() || 'Mock Result'
+    return mockPayload || 'Mock Result'
   }
   const aiProvider = await store.get('ai_provider')
   let process: (text: string, abortSignal?: AbortSignal, preResolved?: { text: string, prompt: string, command?: string }) => Promise<string>

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -257,6 +257,7 @@ let abortController: AbortController | null = null
 
 async function fetchCorrection(text: string, preResolved?: { text: string, prompt: string, command?: string }): Promise<string> {
   abortController = new AbortController()
+  const signal = abortController.signal
 
   const mockPrefixMatch = text.match(/^\s*\/mock\b/)
   if (import.meta.env.DEV && mockPrefixMatch) {
@@ -265,14 +266,14 @@ async function fetchCorrection(text: string, preResolved?: { text: string, promp
       let timeout: ReturnType<typeof setTimeout>
       const onAbort = () => {
         clearTimeout(timeout)
-        abortController?.signal.removeEventListener('abort', onAbort)
+        signal.removeEventListener('abort', onAbort)
         reject(new DOMException('Aborted', 'AbortError'))
       }
       timeout = setTimeout(() => {
-        abortController?.signal.removeEventListener('abort', onAbort)
+        signal.removeEventListener('abort', onAbort)
         resolve()
       }, 5000)
-      abortController?.signal.addEventListener('abort', onAbort)
+      signal.addEventListener('abort', onAbort)
     })
     return mockPayload || 'Mock Result'
   }

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -441,6 +441,13 @@ async function onESC() {
 async function openMainWindow() {
   await invoke('open_main_window')
 }
+
+async function handleErrorClick() {
+  if (isRateLimited.value) {
+    await login()
+    await hideIndicator()
+  }
+}
 </script>
 
 <template>
@@ -483,8 +490,8 @@ async function openMainWindow() {
           v-else-if="state === 'error'"
           class="truncate text-sm text-red-400 px-2 font-medium cursor-pointer hover:underline"
           :data-tauri-drag-region="isRateLimited ? undefined : true"
-          @mousedown="isRateLimited && $event.stopPropagation()"
-          @click="isRateLimited ? (login(), hideIndicator()) : null"
+          @mousedown="isRateLimited ? $event.stopPropagation() : undefined"
+          @click="handleErrorClick"
         >
           {{ errorText }}
         </p>

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -259,6 +259,8 @@ async function fetchCorrection(text: string, preResolved?: { text: string, promp
   abortController = new AbortController()
   const signal = abortController.signal
 
+  // Note: only for development
+  // handle `/mock` prefix
   const mockPrefixMatch = text.match(/^\s*\/mock\b/)
   if (import.meta.env.DEV && mockPrefixMatch) {
     const mockPayload = text.slice(mockPrefixMatch[0].length).trim()

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -265,6 +265,7 @@ async function fetchCorrection(text: string, preResolved?: { text: string, promp
       let timeout: ReturnType<typeof setTimeout>
       const onAbort = () => {
         clearTimeout(timeout)
+        abortController?.signal.removeEventListener('abort', onAbort)
         reject(new DOMException('Aborted', 'AbortError'))
       }
       timeout = setTimeout(() => {
@@ -490,6 +491,7 @@ function gotoSettings() {
       <!-- Right: Settings -->
       <button
         class="size-7 shrink-0 flex items-center justify-center rounded-lg hover:bg-white/5 transition-colors cursor-pointer"
+        :data-tauri-drag-region="false"
         @click="gotoSettings"
       >
         <SettingsIcon class="w-4 h-4 text-white/40 hover:text-white/60" />

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -256,13 +256,23 @@ onUnmounted(() => {
 let abortController: AbortController | null = null
 
 async function fetchCorrection(text: string, preResolved?: { text: string, prompt: string, command?: string }): Promise<string> {
+  abortController = new AbortController()
+
   const mockMatch = text.match(/^\s*\/mock(?:\s+([\s\S]*))?$/)
   if (import.meta.env.DEV && mockMatch) {
-    await sleep(5000)
-    return `${text.trim()}`
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        clearTimeout(timeout)
+        reject(new DOMException('Aborted', 'AbortError'))
+      }
+      const timeout = setTimeout(() => {
+        abortController?.signal.removeEventListener('abort', onAbort)
+        resolve()
+      }, 5000)
+      abortController?.signal.addEventListener('abort', onAbort)
+    })
+    return mockMatch[1]?.trim() || 'Mock Result'
   }
-
-  abortController = new AbortController()
   const aiProvider = await store.get('ai_provider')
   let process: (text: string, abortSignal?: AbortSignal, preResolved?: { text: string, prompt: string, command?: string }) => Promise<string>
   switch (aiProvider) {
@@ -485,9 +495,13 @@ function gotoSettings() {
     </div>
   </div>
 </template>
-
 <style scoped>
-body, .indicator-shell {
+:global(body) {
+  background-color: transparent;
+  overflow: hidden;
+}
+
+.indicator-shell {
   position: relative;
   border-radius: 0.625rem;
   background-color: transparent;
@@ -496,7 +510,7 @@ body, .indicator-shell {
 
 .indicator-capsule {
   position: relative;
-  box-shadow: 0 10px 30px rgb(0 0 0 / 24%);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
 }
 
 .indicator-content {
@@ -510,7 +524,7 @@ body, .indicator-shell {
   pointer-events: none;
   border-radius: inherit;
   z-index: 0;
-  background-color: rgb(38 38 38);
+  background-color: rgb(52 52 52);
 }
 
 .indicator-shell--processing::before {

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -482,7 +482,8 @@ async function openMainWindow() {
         <p
           v-else-if="state === 'error'"
           class="truncate text-sm text-red-400 px-2 font-medium cursor-pointer hover:underline"
-          :data-tauri-drag-region="isRateLimited ? false : true"
+          :data-tauri-drag-region="isRateLimited ? undefined : true"
+          @mousedown="isRateLimited && $event.stopPropagation()"
           @click="isRateLimited ? (login(), hideIndicator()) : null"
         >
           {{ errorText }}
@@ -496,7 +497,7 @@ async function openMainWindow() {
       <!-- Right: Settings -->
       <button
         class="size-7 shrink-0 flex items-center justify-center rounded-lg hover:bg-white/5 transition-colors cursor-pointer"
-        data-tauri-drag-region="false"
+        @mousedown.stop
         @click="openMainWindow"
       >
         <SettingsIcon class="w-4 h-4 text-white/40 hover:text-white/60" />

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -2,7 +2,7 @@
 import type { UnlistenFn } from '@tauri-apps/api/event'
 import { invoke } from '@tauri-apps/api/core'
 import { LogicalSize } from '@tauri-apps/api/dpi'
-import { emit, listen } from '@tauri-apps/api/event'
+import { listen } from '@tauri-apps/api/event'
 import { getCurrentWindow } from '@tauri-apps/api/window'
 import { writeText } from '@tauri-apps/plugin-clipboard-manager'
 import { ClipboardCheckIcon, Loader2Icon, SettingsIcon, TerminalIcon } from 'lucide-vue-next'
@@ -433,8 +433,8 @@ async function onESC() {
   await hideIndicator()
 }
 
-function gotoSettings() {
-  emit('open-settings')
+async function openMainWindow() {
+  await invoke('open_main_window')
 }
 </script>
 
@@ -492,7 +492,7 @@ function gotoSettings() {
       <button
         class="size-7 shrink-0 flex items-center justify-center rounded-lg hover:bg-white/5 transition-colors cursor-pointer"
         :data-tauri-drag-region="false"
-        @click="gotoSettings"
+        @click="openMainWindow"
       >
         <SettingsIcon class="w-4 h-4 text-white/40 hover:text-white/60" />
       </button>

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -263,6 +263,10 @@ async function fetchCorrection(text: string, preResolved?: { text: string, promp
   if (import.meta.env.DEV && mockPrefixMatch) {
     const mockPayload = text.slice(mockPrefixMatch[0].length).trim()
     await new Promise<void>((resolve, reject) => {
+      if (signal.aborted) {
+        reject(new DOMException('Aborted', 'AbortError'))
+        return
+      }
       let timeout: ReturnType<typeof setTimeout>
       const onAbort = () => {
         clearTimeout(timeout)
@@ -492,7 +496,7 @@ async function openMainWindow() {
       <!-- Right: Settings -->
       <button
         class="size-7 shrink-0 flex items-center justify-center rounded-lg hover:bg-white/5 transition-colors cursor-pointer"
-        :data-tauri-drag-region="false"
+        data-tauri-drag-region="false"
         @click="openMainWindow"
       >
         <SettingsIcon class="w-4 h-4 text-white/40 hover:text-white/60" />

--- a/apps/desktop/src/windows/Indicator.vue
+++ b/apps/desktop/src/windows/Indicator.vue
@@ -263,7 +263,10 @@ async function fetchCorrection(text: string, preResolved?: { text: string, promp
   if (import.meta.env.DEV && text.trim().startsWith('/mock')) {
     await new Promise((resolve, reject) => {
       const t = setTimeout(resolve, 5000)
-      signal.addEventListener('abort', () => { clearTimeout(t); reject(new DOMException('Aborted', 'AbortError')) }, { once: true })
+      signal.addEventListener('abort', () => {
+        clearTimeout(t)
+        reject(new DOMException('Aborted', 'AbortError'))
+      }, { once: true })
     })
     return text.replace(/^\s*\/mock/, '').trim() || 'Mock Result'
   }

--- a/apps/desktop/src/windows/Main.vue
+++ b/apps/desktop/src/windows/Main.vue
@@ -88,6 +88,14 @@ onMounted(async () => {
     unlistenOpenSettings = unlisten
   }
 
+  const shouldOpenSettings = await invoke<boolean>('consume_pending_open_settings')
+  if (!isMounted) {
+    return
+  }
+  if (shouldOpenSettings) {
+    activeTab.value = 'settings'
+  }
+
   const systemInfo = await invoke<{ os: string, version: string, is_wayland: boolean }>('get_system_info')
   if (!isMounted) {
     return

--- a/apps/desktop/src/windows/Main.vue
+++ b/apps/desktop/src/windows/Main.vue
@@ -79,6 +79,7 @@ onMounted(async () => {
 
   const unlisten = await listen('open-settings', () => {
     activeTab.value = 'settings'
+    void invoke('consume_pending_open_settings')
   })
 
   if (!isMounted) {


### PR DESCRIPTION
## Summary
- Add new indicator-shell wrapper with animated gradient border for processing state
- Increase indicator height from 56 to 60px
- Add /mock command for dev testing

## Test plan
- [ ] Verify indicator displays correctly in idle state
- [ ] Verify animated gradient border appears during processing
- [ ] Test /mock command in dev mode