### PR TITLE
fix: unify desktop CLI option handling

### DIFF
--- a/apps/desktop/src-tauri/src/cli.rs
+++ b/apps/desktop/src-tauri/src/cli.rs
@@ -1,5 +1,46 @@
 const SELECTION_FLAG: &str = "--selection";
 const VERSION_FLAG: &str = "--version";
+const HELP_FLAG: &str = "--help";
+const HELP_SHORT_FLAG: &str = "-h";
+
+enum CliCommand {
+    None,
+    Selection,
+    Version,
+    Help,
+}
+
+pub struct StartupCliOptions {
+    pub should_exit: bool,
+    pub startup_selection: bool,
+}
+
+fn detect_command<I, S>(args: I) -> CliCommand
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut has_selection = false;
+
+    for arg in args {
+        let arg = arg.as_ref();
+        if arg == VERSION_FLAG {
+            return CliCommand::Version;
+        }
+        if arg == HELP_FLAG || arg == HELP_SHORT_FLAG {
+            return CliCommand::Help;
+        }
+        if arg == SELECTION_FLAG {
+            has_selection = true;
+        }
+    }
+
+    if has_selection {
+        CliCommand::Selection
+    } else {
+        CliCommand::None
+    }
+}
 
 pub fn has_selection_flag<I, S>(args: I) -> bool
 where
@@ -17,6 +58,42 @@ where
     args.into_iter().any(|arg| arg.as_ref() == VERSION_FLAG)
 }
 
+pub fn evaluate_startup_options<I, S>(args: I, is_wayland: bool) -> StartupCliOptions
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    match detect_command(args) {
+        CliCommand::Version => {
+            println!("typo {}", env!("CARGO_PKG_VERSION"));
+            StartupCliOptions {
+                should_exit: true,
+                startup_selection: false,
+            }
+        }
+        CliCommand::Help => {
+            println!("Usage: typo [OPTIONS]");
+            println!();
+            println!("Options:");
+            println!("  --selection    Trigger selection mode (Wayland startup path)");
+            println!("  --version      Print version");
+            println!("  --help, -h     Show this help message");
+            StartupCliOptions {
+                should_exit: true,
+                startup_selection: false,
+            }
+        }
+        CliCommand::Selection => StartupCliOptions {
+            should_exit: false,
+            startup_selection: is_wayland,
+        },
+        CliCommand::None => StartupCliOptions {
+            should_exit: false,
+            startup_selection: false,
+        },
+    }
+}
+
 pub fn handle_single_instance_event(
     app: &tauri::AppHandle,
     argv: &[String],
@@ -25,14 +102,25 @@ pub fn handle_single_instance_event(
 ) {
     use tauri::Manager;
 
-    if has_version_flag(argv.iter().map(|arg| arg.as_str())) {
-        println!("typo {}", env!("CARGO_PKG_VERSION"));
-        return;
-    }
-
-    if has_selection_flag(argv.iter().map(|arg| arg.as_str())) && is_wayland {
-        selection_handler(app);
-        return;
+    match detect_command(argv.iter().map(|arg| arg.as_str())) {
+        CliCommand::Version => {
+            println!("typo {}", env!("CARGO_PKG_VERSION"));
+            return;
+        }
+        CliCommand::Help => {
+            println!("Usage: typo [OPTIONS]");
+            println!();
+            println!("Options:");
+            println!("  --selection    Trigger selection mode (Wayland startup path)");
+            println!("  --version      Print version");
+            println!("  --help, -h     Show this help message");
+            return;
+        }
+        CliCommand::Selection if is_wayland => {
+            selection_handler(app);
+            return;
+        }
+        CliCommand::Selection | CliCommand::None => {}
     }
 
     if let Some(window) = app.get_webview_window("main") {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -190,7 +190,12 @@ fn open_log_folder(app: tauri::AppHandle) -> Result<(), String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let startup_selection = cli::has_selection_flag(std::env::args());
+    let startup_cli_options = cli::evaluate_startup_options(std::env::args(), in_linux_wayland());
+    if startup_cli_options.should_exit {
+        return;
+    }
+
+    let startup_selection = startup_cli_options.startup_selection;
 
     tauri::Builder::default()
         .plugin(tauri_plugin_http::init())
@@ -222,7 +227,7 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
 
-            if startup_selection && in_linux_wayland() {
+            if startup_selection {
                 app_cli_startup_selection_trigger(&app.handle());
             }
             Ok(())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -136,11 +136,14 @@ fn app_cli_startup_selection_trigger(app: &tauri::AppHandle) {
     };
 
     if let Some(text) = text {
-        if let Ok(mut pending) = pending_selection_payload().lock() {
-            *pending = Some(SetInputPayload {
-                text,
-                mode: "selected".to_string(),
-            });
+        match pending_selection_payload().lock() {
+            Ok(mut pending) => {
+                *pending = Some(SetInputPayload {
+                    text,
+                    mode: "selected".to_string(),
+                });
+            }
+            Err(error) => log::error!("failed to access pending selection payload: {}", error),
         }
     }
 }
@@ -158,8 +161,11 @@ fn consume_pending_selection_input() -> Option<SetInputPayload> {
 
 #[tauri::command]
 fn set_pending_selection_input(payload: SetInputPayload) {
-    if let Ok(mut pending) = pending_selection_payload().lock() {
-        *pending = Some(payload);
+    match pending_selection_payload().lock() {
+        Ok(mut pending) => {
+            *pending = Some(payload);
+        }
+        Err(error) => log::error!("failed to access pending selection payload: {}", error),
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize desktop CLI command detection in `cli.rs` for startup and single-instance events
- ensure `--version` exits cleanly without opening the UI in startup and second-invocation flows
- add `--help`/`-h` output and keep `--selection` Wayland-gated via unified startup options

## Test plan
- [x] Run `typo --version` and verify it prints version and exits
- [x] Run `typo --help` and verify usage output
- [x] Run `typo --selection` on Wayland and verify selection flow still triggers