### PR TITLE
👷 [desktop]: Add Swatinem/rust-cache to CI and release workflows

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -9,6 +9,7 @@ on:
       - pnpm-workspace.yaml
       - package.json
       - .github/workflows/desktop-ci.yml
+      - .github/workflows/desktop-release.yml
   pull_request:
     branches: [main]
     paths: *desktop_paths
@@ -54,6 +55,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
 
       - name: Install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -53,6 +53,10 @@ jobs:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+
       - name: Install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
         run: |


### PR DESCRIPTION
## Summary
- Add `Swatinem/rust-cache@v2` after the Rust toolchain step in `desktop-ci.yml` and `desktop-release.yml`, scoped to `apps/desktop/src-tauri`.
- Include `desktop-release.yml` in the desktop CI path filters so workflow-only changes still run the desktop build.

## Test plan
- [ ] Wait for desktop CI on this PR (first run may be a cache miss; subsequent runs should be faster).
- [ ] Confirm release workflow still passes on the next tag (cache should help repeat releases).


Made with [Cursor](https://cursor.com)