### PR TITLE
🐛 [desktop]: Run enigo_copy on the main thread on macOS to prevent crashes

### DIFF
--- a/apps/desktop/src-tauri/src/keyboard.rs
+++ b/apps/desktop/src-tauri/src/keyboard.rs
@@ -39,7 +39,7 @@ pub(crate) fn enigo_copy(app: &tauri::AppHandle) -> Result<(), String> {
         extern "C" {
             fn pthread_main_np() -> std::os::raw::c_int;
         }
-        let is_main_thread = unsafe { pthread_main_np() != 0 };
+        let is_main_thread = unsafe { pthread_main_np() == 1 };
 
         if is_main_thread {
             enigo_copy_raw()

--- a/apps/desktop/src-tauri/src/keyboard.rs
+++ b/apps/desktop/src-tauri/src/keyboard.rs
@@ -23,14 +23,36 @@ fn new_enigo() -> Result<(enigo::Enigo, enigo::Key), String> {
 }
 
 /// Sends `Ctrl + c` (Linux/Windows) or `Cmd + c` (macOS) to copy the current selection.
-pub(crate) fn enigo_copy() -> Result<(), String> {
-    let (mut enigo, modifier) = new_enigo()?;
+pub(crate) fn enigo_copy(app: &tauri::AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
+        app.run_on_main_thread(move || {
+            let res = (|| {
+                let (mut enigo, modifier) = new_enigo()?;
+                let _ = enigo.key(modifier, enigo::Direction::Press);
+                let _ = enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click);
+                let _ = enigo.key(modifier, enigo::Direction::Release);
+                Ok(())
+            })();
+            let _ = tx.send(res);
+        })
+        .map_err(|e| e.to_string())?;
 
-    let _ = enigo.key(modifier, enigo::Direction::Press);
-    let _ = enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click);
-    let _ = enigo.key(modifier, enigo::Direction::Release);
+        rx.recv().unwrap_or_else(|_| Err("Copy failed".into()))
+    }
 
-    Ok(())
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        let (mut enigo, modifier) = new_enigo()?;
+
+        let _ = enigo.key(modifier, enigo::Direction::Press);
+        let _ = enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click);
+        let _ = enigo.key(modifier, enigo::Direction::Release);
+
+        Ok(())
+    }
 }
 
 /// Sends `Ctrl + v` (Linux/Windows) or `Cmd + v` (macOS) to paste from the clipboard.

--- a/apps/desktop/src-tauri/src/keyboard.rs
+++ b/apps/desktop/src-tauri/src/keyboard.rs
@@ -22,36 +22,42 @@ fn new_enigo() -> Result<(enigo::Enigo, enigo::Key), String> {
     Ok((enigo, modifier))
 }
 
+fn enigo_copy_raw() -> Result<(), String> {
+    let (mut enigo, modifier) = new_enigo()?;
+
+    let _ = enigo.key(modifier, enigo::Direction::Press);
+    let _ = enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click);
+    let _ = enigo.key(modifier, enigo::Direction::Release);
+
+    Ok(())
+}
+
 /// Sends `Ctrl + c` (Linux/Windows) or `Cmd + c` (macOS) to copy the current selection.
 pub(crate) fn enigo_copy(app: &tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
-        let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
-        app.run_on_main_thread(move || {
-            let res = (|| {
-                let (mut enigo, modifier) = new_enigo()?;
-                let _ = enigo.key(modifier, enigo::Direction::Press);
-                let _ = enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click);
-                let _ = enigo.key(modifier, enigo::Direction::Release);
-                Ok(())
-            })();
-            let _ = tx.send(res);
-        })
-        .map_err(|e| e.to_string())?;
+        extern "C" {
+            fn pthread_main_np() -> std::os::raw::c_int;
+        }
+        let is_main_thread = unsafe { pthread_main_np() != 0 };
 
-        rx.recv().unwrap_or_else(|_| Err("Copy failed".into()))
+        if is_main_thread {
+            enigo_copy_raw()
+        } else {
+            let (tx, rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
+            app.run_on_main_thread(move || {
+                let _ = tx.send(enigo_copy_raw());
+            })
+            .map_err(|e| e.to_string())?;
+
+            rx.recv().unwrap_or_else(|_| Err("Copy failed".into()))
+        }
     }
 
     #[cfg(not(target_os = "macos"))]
     {
         let _ = app;
-        let (mut enigo, modifier) = new_enigo()?;
-
-        let _ = enigo.key(modifier, enigo::Direction::Press);
-        let _ = enigo.key(enigo::Key::Unicode('c'), enigo::Direction::Click);
-        let _ = enigo.key(modifier, enigo::Direction::Release);
-
-        Ok(())
+        enigo_copy_raw()
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -121,7 +121,7 @@ pub(crate) fn get_selected_text_wayland(app: &tauri::AppHandle) -> Option<String
 }
 
 pub(crate) fn get_selected_text_enigo(app: &tauri::AppHandle) -> Option<String> {
-    keyboard::enigo_copy().ok()?;
+    keyboard::enigo_copy(app).ok()?;
 
     std::thread::sleep(std::time::Duration::from_millis(100));
 


### PR DESCRIPTION
## Summary
- Modifies `enigo_copy` in `keyboard.rs` to run on the main thread on macOS via `run_on_main_thread`.
- Passes the `tauri::AppHandle` parameter to `enigo_copy` to enable main-thread execution on macOS.
- Updates the caller `get_selected_text_enigo` in `lib.rs` to pass `app` to `enigo_copy`.

## Test plan
- [x] Verified code compilation via `cargo check` in `apps/desktop/src-tauri` which completed successfully.
- [ ] Manual verification on macOS to trigger the quick pick shortcut and confirm no crashes occur when capturing text.
